### PR TITLE
Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,18 @@ __pycache__/
 Icon?
 ehthumbs.db
 Thumbs.db
+
+ Covers JetBrains PyCharm
+ ######################
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml


### PR DESCRIPTION
Hello,

I was trying to run on Windows and was getting an error.
The offending line is (https://github.com/nextstrain/cli/blob/master/nextstrain/cli/runner/docker.py#L105):
``` python
 # Run the process in the container with the same UID/GID so that file
 # ownership is correct in the bind mount directories.
 "--user=%d:%d" % (os.getuid(), os.getgid()),
```

Because `os.getuid()` and `os.getgid()` does not exist on Windows platforms. 

Opening a Pull Request to go around this limitation by only adding the `--user` argument if not on Windows. The file rights are much more lenient on Windows and therefore it is unnecessary to run as the current user. 

Also added some ignore files in the `.gitignore` for all the JetBrains generated files (useful if somebody is using PyCharm to develop).

Thanks,


