### PR TITLE
view: Optionally allow remote network access to the webserver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,7 @@ setup(
         ],
     },
 
-    install_requires = [],
+    install_requires = [
+        "netifaces >=0.10.6",
+    ],
 )


### PR DESCRIPTION
This lets folks run `nextstrain view` on their computer and then share
the link with others on their network.  The original motivation for this
feature is to let Ashley run Nextstrain on her computer and have her
students connect to it from their computers.  However, it's also easy to
see how it would be useful in development when working collaboratively.

The default is still local access only so that the command is secure by
default.

This adds the first external dependency to the package.  Though the
feature and dep are non-essential, I opted not to make it part of an
optional feature tag under the reasoning that "batteries included" was a
better fit for our users.  If dependencies cause installation woes down
the road, then we should reconsider that choice.