### PR TITLE
specify /local/ in auspice URLs

### DIFF
--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -112,7 +112,7 @@ def print_url(host, port, datasets):
     def url(path = None):
         return colored(
             "blue",
-            "http://{host}:{port}/{path}".format(
+            "http://{host}:{port}/local/{path}".format(
                 host = host,
                 port = port,
                 path = path if path is not None else ""))


### PR DESCRIPTION
This prepends `local` to the URL displayed by `nextstrain view`, to reflect auspice updates in v1.23.0 (already in the docker build)