### PR TITLE
Check for newer versions of the CLI itself…

### DIFF
--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -9,7 +9,7 @@ installed and configured, which this command will test by running:
 """
 
 from functools import partial
-from ..util import colored
+from ..util import colored, check_for_new_version
 from ..runner import all_runners
 
 
@@ -27,6 +27,9 @@ def run(opts):
         True:  success("✔"),
         False: failure("✘"),
     }
+
+    # Check our own version for updates
+    check_for_new_version()
 
     # Run and collect our runners' self-tests
     print("Testing your setup…")

--- a/nextstrain/cli/command/update.py
+++ b/nextstrain/cli/command/update.py
@@ -5,7 +5,7 @@ This may take several minutes as the layers of the image are downloaded.
 """
 
 from functools import partial
-from ..util import colored
+from ..util import colored, check_for_new_version
 from ..runner import all_runners
 
 
@@ -16,8 +16,12 @@ def register_parser(subparser):
 
 
 def run(opts):
+    # Check our own version for updates
+    newer_version = check_for_new_version()
+
     success = partial(colored, "green")
     failure = partial(colored, "red")
+    notice  = partial(colored, "yellow")
 
     statuses = [
         runner.update()
@@ -27,8 +31,18 @@ def run(opts):
     # Print overall status
     all_good = False not in statuses
 
-    print()
-    print(success("Up to date!") if all_good else failure("Update failed"))
+    if all_good:
+        print()
+        print(success("Your images are up to date!"))
+        if newer_version:
+            print()
+            print(notice("…but consider upgrading nextstrain-cli too, as noted above."))
+    else:
+        print()
+        print(failure("Updating images failed"))
+        if newer_version:
+            print()
+            print(notice("Maybe upgrading nextstrain-cli, as noted above, will help?"))
 
     # Return a 1 or 0 exit code
     return int(not all_good)

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -181,6 +181,8 @@ def test_setup():
 
 
 def update():
+    print("Updating Docker image %s…" % DEFAULT_IMAGE)
+    print()
     try:
         status = subprocess.run(
             ["docker", "image", "pull", DEFAULT_IMAGE],

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -1,5 +1,9 @@
 import re
+import requests
+from pkg_resources import parse_version
 from sys import stderr
+from .__version__ import __version__
+
 
 def warn(*args):
     print(*args, file = stderr)
@@ -32,3 +36,38 @@ def remove_prefix(prefix, string):
 
 def remove_suffix(suffix, string):
     return re.sub(re.escape(suffix) + '$', '', string)
+
+
+def check_for_new_version():
+    newer_version = new_version_available()
+
+    if newer_version:
+        print("A new version of nextstrain-cli, %s, is available!  You're running %s." % (newer_version, __version__))
+        print()
+        print("Upgrade by running:")
+        print()
+        print("    pip install --upgrade nextstrain-cli")
+        print()
+    else:
+        print("nextstrain-cli is up to date!")
+        print()
+
+    return newer_version
+
+
+def new_version_available():
+    """
+    Return the latest version of nextstrain-cli on PyPi if it's newer than the
+    currently running version.  Otherwise return None.
+    """
+    this_version   = parse_version(__version__)
+    latest_version = parse_version(fetch_latest_pypi_version("nextstrain-cli"))
+
+    return latest_version if latest_version > this_version else None
+
+
+def fetch_latest_pypi_version(project):
+    """
+    Return the latest version of the given project from PyPi.
+    """
+    return requests.get("https://pypi.python.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")

--- a/setup.py
+++ b/setup.py
@@ -78,5 +78,6 @@ setup(
     install_requires = [
         "boto3",
         "netifaces >=0.10.6",
+        "requests",
     ],
 )


### PR DESCRIPTION
…in the check-setup and update commands.  These two commands already
come with the expectation that self-tests will be run and network
connections made, so it seems not very intrusive to do our own version
checking as well.

The idea is to prompt people to upgrade the CLI itself when they're
already thinking about their setup and not to distract or nag them when
they're running builds or viewing results.  Having people stay
relatively up-to-date on the CLI versions should make our development
easier.

Resolves #16.