### PR TITLE
Automatically prune old images after running update

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -184,10 +184,10 @@ def update():
     print("Updating Docker image %s…" % DEFAULT_IMAGE)
     print()
     try:
-        status = subprocess.run(
+        subprocess.run(
             ["docker", "image", "pull", DEFAULT_IMAGE],
             check = True)
     except:
         return False
-    else:
-        return status.returncode == 0
+
+    return True

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -8,7 +8,7 @@ import argparse
 import subprocess
 from collections import namedtuple
 from pathlib import Path
-from ..util import warn
+from ..util import warn, colored
 
 
 DEFAULT_IMAGE = "nextstrain/base"
@@ -181,7 +181,7 @@ def test_setup():
 
 
 def update():
-    print("Updating Docker image %s…" % DEFAULT_IMAGE)
+    print(colored("bold", "Updating Docker image %s…" % DEFAULT_IMAGE))
     print()
 
     # Pull the latest image down
@@ -197,7 +197,7 @@ def update():
     # want to just remove _our_ dangling images, not all.  We very much don't
     # want to automatically prune unrelated images.
     print()
-    print("Pruning old copies of image…")
+    print(colored("bold", "Pruning old copies of image…"))
     print()
 
     try:

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -187,7 +187,7 @@ def update():
         subprocess.run(
             ["docker", "image", "pull", DEFAULT_IMAGE],
             check = True)
-    except:
+    except subprocess.CalledProcessError:
         return False
 
     return True

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -183,6 +183,8 @@ def test_setup():
 def update():
     print("Updating Docker image %s…" % DEFAULT_IMAGE)
     print()
+
+    # Pull the latest image down
     try:
         subprocess.run(
             ["docker", "image", "pull", DEFAULT_IMAGE],
@@ -190,4 +192,47 @@ def update():
     except subprocess.CalledProcessError:
         return False
 
+    # Prune any old images which are now dangling to avoid leaving lots of
+    # hidden disk use around.  We don't use `docker image prune` because we
+    # want to just remove _our_ dangling images, not all.  We very much don't
+    # want to automatically prune unrelated images.
+    print()
+    print("Pruning old copies of image…")
+    print()
+
+    try:
+        images = dangling_images(DEFAULT_IMAGE)
+
+        if images:
+            subprocess.run(
+                ["docker", "image", "rm", *images],
+                check = True)
+    except subprocess.CalledProcessError as error:
+        warn("Error pruning old image versions: ", error)
+        return False
+
     return True
+
+
+def dangling_images(name):
+    """
+    Return a list of Docker image IDs which are untagged ("dangling") and thus
+    likely no longer in use.
+
+    Since dangling images are untagged, this finds images by name using our
+    custom org.nextstrain.image.name label.
+    """
+    name_sans_tag = name.split(":")[0]
+
+    # Set stdout = PIPE and decode the result ourselves instead of using the
+    # new capture_output parameter added in Python 3.7.  We're aiming for 3.5.
+    result = subprocess.run(
+        ["docker", "image", "ls",
+            "--no-trunc",
+            "--format={{.ID}}",
+            "--filter=dangling=true",
+            "--filter=label=org.nextstrain.image.name=%s" % name_sans_tag],
+        stdout = subprocess.PIPE,
+        check  = True)
+
+    return result.stdout.decode("utf-8").splitlines()

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -21,6 +21,7 @@ def colored(color, text):
         "green":  "\033[0;32m",
         "blue":   "\033[0;1;34m",
         "yellow": "\033[0;33m",
+        "bold":   "\033[1m",
         "reset":  "\033[0m",
     }
 


### PR DESCRIPTION
See commits for more details.  Resolves #23.

Depends on image labels added by https://github.com/nextstrain/docker-base/pull/15