### PR TITLE
Report Docker image id and timestamp in version output

### DIFF
--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -3,6 +3,8 @@ Nextstrain command-line tool
 """
 
 
+import sys
+import argparse
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter
 from types    import SimpleNamespace
 
@@ -41,6 +43,7 @@ def run(args):
 
     register_default_command(parser)
     register_commands(parser, commands)
+    register_version_alias(parser)
 
     opts = parser.parse_args(args)
     return opts.__command__.run(opts)
@@ -70,3 +73,23 @@ def register_commands(parser, commands):
 
         # Ensure all subparsers format like the top-level parser
         subparser.formatter_class = parser.formatter_class
+
+
+def register_version_alias(parser):
+    """
+    Add --version as a (hidden) alias for the version command.
+
+    It's not uncommon to blindly run a command with --version as the sole
+    argument, so its useful to make that Just Work.
+    """
+
+    class run_version_command(argparse.Action):
+        def __call__(self, *args, **kwargs):
+            empty_opts = SimpleNamespace()
+            sys.exit( version.run(empty_opts) )
+
+    parser.add_argument(
+        "--version",
+        nargs  = 0,
+        help   = argparse.SUPPRESS,
+        action = run_version_command)

--- a/nextstrain/cli/command/version.py
+++ b/nextstrain/cli/command/version.py
@@ -1,5 +1,6 @@
 from ..__version__ import __version__
 from .. import __package__ as __top_package__
+from ..runner import all_runners
 
 def register_parser(subparser):
     return subparser.add_parser(
@@ -14,3 +15,6 @@ def register_parser(subparser):
 
 def run(opts):
     print(__top_package__, __version__)
+
+    for runner in all_runners:
+        runner.print_version()

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -232,3 +232,28 @@ def dangling_images(name):
             "--filter=label=org.nextstrain.image.name=%s" % name_sans_tag
     ])
 
+
+def print_version():
+    """
+    Print the Docker image name and version.
+    """
+    # Qualify the name with the "latest" tag if necessary so we only get a
+    # single id back.
+    qualified_image = DEFAULT_IMAGE
+
+    if ":" not in DEFAULT_IMAGE:
+        qualified_image += ":latest"
+
+    image_ids = capture_output([
+        "docker", "image", "ls",
+            "--format={{.ID}} ({{.CreatedAt}})", qualified_image])
+
+    assert len(image_ids) <= 1
+
+    # Print the default image name as-is, without the implicit :latest
+    # qualification (if any).  The :latest tag is often confusing, as it
+    # doesn't mean you have the latest version.  Thus we avoid it.
+    #
+    # This function (via the version command), may be run before the image is
+    # downloaded, so we handle finding no image ids.
+    print("%s docker image %s" % (DEFAULT_IMAGE, image_ids[0] if image_ids else "not present"))

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -8,7 +8,7 @@ import argparse
 import subprocess
 from collections import namedtuple
 from pathlib import Path
-from ..util import warn, colored
+from ..util import warn, colored, capture_output
 
 
 DEFAULT_IMAGE = "nextstrain/base"
@@ -224,15 +224,11 @@ def dangling_images(name):
     """
     name_sans_tag = name.split(":")[0]
 
-    # Set stdout = PIPE and decode the result ourselves instead of using the
-    # new capture_output parameter added in Python 3.7.  We're aiming for 3.5.
-    result = subprocess.run(
-        ["docker", "image", "ls",
+    return capture_output([
+        "docker", "image", "ls",
             "--no-trunc",
             "--format={{.ID}}",
             "--filter=dangling=true",
-            "--filter=label=org.nextstrain.image.name=%s" % name_sans_tag],
-        stdout = subprocess.PIPE,
-        check  = True)
+            "--filter=label=org.nextstrain.image.name=%s" % name_sans_tag
+    ])
 
-    return result.stdout.decode("utf-8").splitlines()

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -1,5 +1,6 @@
 import re
 import requests
+import subprocess
 from pkg_resources import parse_version
 from sys import stderr
 from .__version__ import __version__
@@ -72,3 +73,20 @@ def fetch_latest_pypi_version(project):
     Return the latest version of the given project from PyPi.
     """
     return requests.get("https://pypi.python.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")
+
+
+def capture_output(argv):
+    """
+    Run the command specified by the argument list and return a list of output
+    lines.
+
+    This wrapper around subprocess.run() exists because its own capture_output
+    parameter wasn't added until Python 3.7 and we aim for compat with 3.5.
+    When we bump our minimum Python version, we can remove this wrapper.
+    """
+    result = subprocess.run(
+        argv,
+        stdout = subprocess.PIPE,
+        check  = True)
+
+    return result.stdout.decode("utf-8").splitlines()


### PR DESCRIPTION
Resolves #8. Includes a commit which aliases `nextstrain --version` to `nextstrain version`, so that people's finger macros Just Work.

Note that this targets merging into master, but only after `prune-images` (PR #24) is merged, as this branch builds upon that work.