### PR TITLE
Native runner (and changes driven by it)

### DIFF
--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -75,6 +75,10 @@ def register_commands(parser, commands):
         # Ensure all subparsers format like the top-level parser
         subparser.formatter_class = parser.formatter_class
 
+        # Default long description to the docstring of the command
+        if not subparser.description and cmd.__doc__:
+            subparser.description = cmd.__doc__
+
 
 def register_version_alias(parser):
     """

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescripti
 from types    import SimpleNamespace
 
 from .command     import build, view, deploy, shell, update, check_setup, version
+from .util        import format_usage
 from .__version__ import __version__
 
 
@@ -74,6 +75,10 @@ def register_commands(parser, commands):
 
         # Ensure all subparsers format like the top-level parser
         subparser.formatter_class = parser.formatter_class
+
+        # Default usage message to the docstring of register_parser()
+        if not subparser.usage and cmd.register_parser.__doc__:
+            subparser.usage = format_usage(cmd.register_parser.__doc__)
 
         # Default long description to the docstring of the command
         if not subparser.description and cmd.__doc__:

--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -1,0 +1,74 @@
+"""
+Custom helpers for extending the behaviour of argparse standard library.
+"""
+
+from argparse import Action, SUPPRESS
+from itertools import takewhile
+
+
+def add_extended_help_flags(parser):
+    """
+    Add --help/-h and --help-all flags to the ArgumentParser.
+
+    Aims to make the default --help output more approachable by truncating it
+    to the most common options.  The full help is available using --help-all.
+    """
+    parser.add_argument(
+        "--help", "-h",
+        help    = "Show a brief help message of common options and exit",
+        action  = ShowBriefHelp)
+
+    parser.add_argument(
+        "--help-all",
+        help    = "Show a full help message of all options and exit",
+        action  = "help")
+
+
+class ShowBriefHelp(Action):
+    def __init__(self, option_strings, help = None, **kwargs):
+        super().__init__(
+            option_strings,
+            help    = help,
+            nargs   = 0,
+            dest    = SUPPRESS,
+            default = SUPPRESS)
+
+    def __call__(self, parser, namespace, values, option_string = None):
+        """
+        Print a truncated version of the standard full help from argparse.
+        """
+        full_help  = parser.format_help()
+        brief_help = self.truncate_help(full_help)
+
+        print(brief_help)
+
+        if len(brief_help) < len(full_help):
+            print("Run again with --help-all instead to see more options.")
+
+        parser.exit()
+
+    def truncate_help(self, full_help):
+        """
+        Truncate the full help after the standard "optional arguments" listing
+        and before any custom argument groups.
+        """
+        seen_optional_arguments_heading = False
+
+        def before_extra_argument_groups(line):
+            """
+            Return True until we've seen the empty line following the
+            hard-coded optional arguments group (that is, all non-positional
+            arguments which aren't in another explicit group).
+            """
+            nonlocal seen_optional_arguments_heading
+
+            if not seen_optional_arguments_heading:
+                if line == "optional arguments:\n":
+                    seen_optional_arguments_heading = True
+
+            return not seen_optional_arguments_heading \
+                or line != "\n"
+
+        lines = full_help.splitlines(keepends = True)
+
+        return "".join(list(takewhile(before_extra_argument_groups, lines)))

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -1,17 +1,23 @@
 """
-Runs a pathogen build in an ephemeral container.
+Runs a pathogen build in the Nextstrain build environment.
 
 The build directory should contain a Snakefile, which will be run with
-snakemake inside the container.
+snakemake.
 
-Docker is the currently the only supported container system.  It must be
-installed and configured, which you can test by running:
+The default build environment is inside an ephemeral Docker container which has
+all the necessary Nextstrain components available.  You may instead run the
+build in the native ambient environment by passing the --native flag, but all
+dependencies must already be installed and configured.
+
+You can test if Docker or native build environments are properly supported on
+your computer by running:
 
     nextstrain check-setup
 
 The `nextstrain build` command is designed to cleanly separate the Nextstrain
-build interface from Docker itself so that we can more seamlessly use other
-container systems in the future as desired or necessary.
+build interface from provisioning a build environment, so that running builds
+is as easy as possible.  It also lets us more seamlessly make environment
+changes in the future as desired or necessary.
 """
 
 from .. import runner

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -21,6 +21,7 @@ changes in the future as desired or necessary.
 """
 
 from .. import runner
+from ..argparse import add_extended_help_flags
 from ..util import warn
 from ..volume import store_volume
 
@@ -31,7 +32,10 @@ def register_parser(subparser):
     %(prog)s --help
     """
 
-    parser = subparser.add_parser("build", help = "Run pathogen build")
+    parser = subparser.add_parser("build", help = "Run pathogen build", add_help = False)
+
+    # Support --help and --help-all
+    add_extended_help_flags(parser)
 
     # Positional parameters
     parser.add_argument(

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -27,7 +27,6 @@ from ..volume import store_volume
 
 def register_parser(subparser):
     parser = subparser.add_parser("build", help = "Run pathogen build")
-    parser.description = __doc__
 
     # Positional parameters
     parser.add_argument(

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -47,4 +47,4 @@ def run(opts):
 
         return 1
 
-    return runner.run(opts)
+    return runner.run(opts, working_volume = opts.build)

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -16,6 +16,7 @@ container systems in the future as desired or necessary.
 
 from ..runner import docker
 from ..util import warn
+from ..volume import store_volume
 
 
 def register_parser(subparser):
@@ -27,7 +28,7 @@ def register_parser(subparser):
         "directory",
         help    = "Path to pathogen build directory",
         metavar = "<directory>",
-        action  = docker.store_volume("build"))
+        action  = store_volume("build"))
 
     # Runner options
     docker.register_arguments(

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -14,7 +14,7 @@ build interface from Docker itself so that we can more seamlessly use other
 container systems in the future as desired or necessary.
 """
 
-from ..runner import docker
+from .. import runner
 from ..util import warn
 from ..volume import store_volume
 
@@ -30,10 +30,8 @@ def register_parser(subparser):
         metavar = "<directory>",
         action  = store_volume("build"))
 
-    # Runner options
-    docker.register_arguments(
-        parser,
-        exec    = ["snakemake", ...])
+    # Register runner flags and arguments
+    runner.register_runners(parser, exec = ["snakemake", ...])
 
     return parser
 
@@ -49,4 +47,4 @@ def run(opts):
 
         return 1
 
-    return docker.run(opts)
+    return runner.run(opts)

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -26,6 +26,11 @@ from ..volume import store_volume
 
 
 def register_parser(subparser):
+    """
+    %(prog)s [options] <directory> [...]
+    %(prog)s --help
+    """
+
     parser = subparser.add_parser("build", help = "Run pathogen build")
 
     # Positional parameters

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -33,8 +33,7 @@ def register_parser(subparser):
     # Runner options
     docker.register_arguments(
         parser,
-        exec    = ["snakemake", ...],
-        volumes = ["sacra", "fauna", "augur"])
+        exec    = ["snakemake", ...])
 
     return parser
 

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -1,11 +1,15 @@
 """
-Checks your local setup to make sure a container runner is installed and works.
+Checks your local setup to see if you have a supported build environment.
 
-Docker is the currently the only supported container system.  It must be
-installed and configured, which this command will test by running:
+Two environments are supported, each of which will be tested:
 
-    docker run --rm hello-world
+  • Our Docker image is the preferred build environment.  Docker itself must
+    be installed and configured on your computer first, but once it is, the
+    build environment is robust and reproducible.
 
+  • Your native ambient environment will be tested for snakemake and augur.
+    Their presence implies a working build environment, but does not guarantee
+    it.
 """
 
 from functools import partial

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -19,7 +19,6 @@ from ..runner import all_runners
 
 def register_parser(subparser):
     parser = subparser.add_parser("check-setup", help = "Test your local setup")
-    parser.description = __doc__
     return parser
 
 

--- a/nextstrain/cli/command/deploy.py
+++ b/nextstrain/cli/command/deploy.py
@@ -54,7 +54,6 @@ SUPPORTED_SCHEMES = {
 
 def register_parser(subparser):
     parser = subparser.add_parser("deploy", help = "Deploy pathogen build")
-    parser.description = __doc__
 
     # Destination
     parser.add_argument(

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -6,6 +6,7 @@ The shell runs inside a container, which requires Docker.  Run `nextstrain
 check-setup` to check if Docker is installed and works.
 """
 
+from .. import runner
 from ..runner import docker
 from ..volume import store_volume
 
@@ -21,10 +22,12 @@ def register_parser(subparser):
         metavar = "<directory>",
         action  = store_volume("build"))
 
-    # Runner options
-    docker.register_arguments(
+    # Register runner flags and arguments; only Docker is supported for now
+    # since a "native" shell doesn't make any sense.
+    runner.register_runners(
         parser,
-        exec    = ["bash", "--login", ...])
+        exec    = ["bash", "--login", ...],
+        runners = [docker])
 
     return parser
 
@@ -40,4 +43,4 @@ def run(opts):
 
         return 1
 
-    return docker.run(opts)
+    return runner.run(opts)

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -7,6 +7,7 @@ check-setup` to check if Docker is installed and works.
 """
 
 from .. import runner
+from ..argparse import add_extended_help_flags
 from ..runner import docker
 from ..volume import store_volume
 
@@ -17,7 +18,10 @@ def register_parser(subparser):
     %(prog)s --help
     """
 
-    parser = subparser.add_parser("shell", help = "Start a new shell in the build environment")
+    parser = subparser.add_parser("shell", help = "Start a new shell in the build environment", add_help = False)
+
+    # Support --help and --help-all
+    add_extended_help_flags(parser)
 
     # Positional parameters
     parser.add_argument(

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -7,6 +7,7 @@ check-setup` to check if Docker is installed and works.
 """
 
 from ..runner import docker
+from ..volume import store_volume
 
 
 def register_parser(subparser):
@@ -18,7 +19,7 @@ def register_parser(subparser):
         "directory",
         help    = "Path to pathogen build directory",
         metavar = "<directory>",
-        action  = docker.store_volume("build"))
+        action  = store_volume("build"))
 
     # Runner options
     docker.register_arguments(

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -12,6 +12,11 @@ from ..volume import store_volume
 
 
 def register_parser(subparser):
+    """
+    %(prog)s [options] <directory> [...]
+    %(prog)s --help
+    """
+
     parser = subparser.add_parser("shell", help = "Start a new shell in the build environment")
 
     # Positional parameters

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -13,7 +13,6 @@ from ..volume import store_volume
 
 def register_parser(subparser):
     parser = subparser.add_parser("shell", help = "Start a new shell in the build environment")
-    parser.description = __doc__
 
     # Positional parameters
     parser.add_argument(

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -31,4 +31,14 @@ def register_parser(subparser):
 
 
 def run(opts):
+    # Ensure our build dir exists
+    if not opts.build.src.is_dir():
+        warn("Error: Build path \"%s\" does not exist or is not a directory." % opts.build.src)
+
+        if not opts.build.src.is_absolute():
+            warn()
+            warn("Perhaps your current working directory is different than you expect?")
+
+        return 1
+
     return docker.run(opts)

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -24,8 +24,7 @@ def register_parser(subparser):
     # Runner options
     docker.register_arguments(
         parser,
-        exec    = ["bash", "--login", ...],
-        volumes = ["sacra", "fauna", "augur", "auspice"])
+        exec    = ["bash", "--login", ...])
 
     return parser
 

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -43,4 +43,4 @@ def run(opts):
 
         return 1
 
-    return runner.run(opts)
+    return runner.run(opts, working_volume = opts.build)

--- a/nextstrain/cli/command/update.py
+++ b/nextstrain/cli/command/update.py
@@ -11,7 +11,6 @@ from ..runner import all_runners
 
 def register_parser(subparser):
     parser = subparser.add_parser("update", help = "Update your local image copy")
-    parser.description = __doc__
     return parser
 
 

--- a/nextstrain/cli/command/version.py
+++ b/nextstrain/cli/command/version.py
@@ -1,3 +1,7 @@
+"""
+Prints the version of the Nextstrain CLI.
+"""
+
 from ..__version__ import __version__
 from .. import __package__ as __top_package__
 from ..runner import all_runners

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -82,9 +82,6 @@ def run(opts):
     host = "0.0.0.0" if opts.allow_remote_access else "127.0.0.1"
     port = 4000
 
-    if opts.docker_args is None:
-        opts.docker_args = []
-
     opts.docker_args = [
         *opts.docker_args,
 

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -20,7 +20,6 @@ from ..volume import store_volume
 
 def register_parser(subparser):
     parser = subparser.add_parser("view", help = "View pathogen build")
-    parser.description = __doc__
 
     parser.add_argument(
         "--allow-remote-access",

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -14,6 +14,7 @@ import re
 import netifaces as net
 from ..runner import docker
 from ..util import colored, warn
+from ..volume import store_volume
 
 
 def register_parser(subparser):
@@ -30,7 +31,7 @@ def register_parser(subparser):
         "directory",
         help    = "Path to pathogen build data directory",
         metavar = "<directory>",
-        action  = docker.store_volume("auspice/data"))
+        action  = store_volume("auspice/data"))
 
     # Runner options
     docker.register_arguments(

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -13,6 +13,7 @@ check-setup` to check if Docker is installed and works.
 import re
 import netifaces as net
 from .. import runner
+from ..argparse import add_extended_help_flags
 from ..runner import docker
 from ..util import colored, warn
 from ..volume import store_volume
@@ -24,7 +25,10 @@ def register_parser(subparser):
     %(prog)s --help
     """
 
-    parser = subparser.add_parser("view", help = "View pathogen build")
+    parser = subparser.add_parser("view", help = "View pathogen build", add_help = False)
+
+    # Support --help and --help-all
+    add_extended_help_flags(parser)
 
     parser.add_argument(
         "--allow-remote-access",

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -103,7 +103,7 @@ def run(opts):
     # Show a helpful message about where to connect
     print_url(host, port, datasets)
 
-    return runner.run(opts)
+    return runner.run(opts, working_volume = opts.auspice_data)
 
 
 def print_url(host, port, datasets):

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -12,6 +12,7 @@ check-setup` to check if Docker is installed and works.
 
 import re
 import netifaces as net
+from .. import runner
 from ..runner import docker
 from ..util import colored, warn
 from ..volume import store_volume
@@ -33,10 +34,12 @@ def register_parser(subparser):
         metavar = "<directory>",
         action  = store_volume("auspice/data"))
 
-    # Runner options
-    docker.register_arguments(
+    # Register runners; only Docker is supported for now since auspice doesn't
+    # have a native wrapper command yet.
+    runner.register_runners(
         parser,
-        exec    = ["auspice"])
+        exec    = ["auspice"],
+        runners = [docker])
 
     return parser
 
@@ -100,7 +103,7 @@ def run(opts):
     # Show a helpful message about where to connect
     print_url(host, port, datasets)
 
-    return docker.run(opts)
+    return runner.run(opts)
 
 
 def print_url(host, port, datasets):

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -36,8 +36,7 @@ def register_parser(subparser):
     # Runner options
     docker.register_arguments(
         parser,
-        exec    = ["auspice"],
-        volumes = ["auspice"])
+        exec    = ["auspice"])
 
     return parser
 

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -19,6 +19,11 @@ from ..volume import store_volume
 
 
 def register_parser(subparser):
+    """
+    %(prog)s [options] <directory>
+    %(prog)s --help
+    """
+
     parser = subparser.add_parser("view", help = "View pathogen build")
 
     parser.add_argument(

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -1,13 +1,14 @@
 import argparse
 from argparse import ArgumentParser
 from typing import Any, List
-from . import docker
+from . import docker, native
 from ..types import Options
 from ..util import runner_name, runner_help
 from ..volume import NamedVolume
 
 all_runners = [
     docker,
+    native,
 ]
 
 default_runner = docker

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, List
 from . import docker
 from ..types import Options
 from ..util import runner_name, runner_help
+from ..volume import NamedVolume
 
 all_runners = [
     docker,
@@ -108,7 +109,7 @@ def register_arguments(parser: ArgumentParser, runners: List, exec: List) -> Non
         runner.register_arguments(parser)
 
 
-def run(opts: Options) -> int:
+def run(opts: Options, working_volume: NamedVolume = None) -> int:
     """
     Inspect the given options object and call the selected runner's run()
     function with appropriate arguments.
@@ -122,7 +123,7 @@ def run(opts: Options) -> int:
         *replace_ellipsis(opts.exec_args, opts.extra_exec_args)
     ]
 
-    return opts.__runner__.run(opts, argv)
+    return opts.__runner__.run(opts, argv, working_volume = working_volume)
 
 
 def replace_ellipsis(items, elided_items):

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -3,3 +3,14 @@ from . import docker
 all_runners = [
     docker,
 ]
+
+
+def replace_ellipsis(items, elided_items):
+    """
+    Replaces any Ellipsis items (...) in a list, if any, with the items of a
+    second list.
+    """
+    return [
+        y for x in items
+          for y in (elided_items if x is ... else [x])
+    ]

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -1,8 +1,128 @@
+import argparse
+from argparse import ArgumentParser
+from typing import Any, List
 from . import docker
+from ..types import Options
+from ..util import runner_name, runner_help
 
 all_runners = [
     docker,
 ]
+
+default_runner = docker
+
+
+# The types of "runners" and "default" are left vague because a generic
+# parameterization isn't easily possible with default values, as reported
+# https://github.com/python/mypy/issues/3737.  The workaround becomes pretty
+# sticky pretty quick for our use case, making it not worth it in my
+# estimation.  It'd make things more confusing rather than more clear.
+#
+# Additionally, there seems to be no way to use the structural/duck typing
+# provided by the Protocol type to annotate a _module_ type with attributes
+# instead of a _class_.  Oh well.
+#   -trs, 15 August 2018
+
+def register_runners(parser:  ArgumentParser,
+                     exec:    List,
+                     runners: List = all_runners,
+                     default: Any  = default_runner) -> None:
+    """
+    Register runner selection flags and runner-specific arguments on the given
+    ArgumentParser instance.
+    """
+    assert default in runners
+    register_flags(parser, runners, default)
+    register_arguments(parser, runners, exec = exec)
+
+
+def register_flags(parser: ArgumentParser, runners: List, default: Any) -> None:
+    """
+    Register runner selection flags on the given ArgumentParser instance.
+    """
+
+    # We use a different flag for each runner for a simpler UX, but only one
+    # runner may be selected from the group.
+    flags = parser.add_mutually_exclusive_group()
+
+    # The selected runner is stored in __runner__ (a la __command__).  The
+    # run() function below calls __runner__.
+    flags.set_defaults( __runner__ = default )
+
+    # Add a flag for each runner based on its name.
+    #
+    # The standard display of option defaults (via ArgumentDefaultsHelpFormatter)
+    # is suppressed so we can provide better custom handling that doesn't
+    # expose full runner module names.
+    for runner in runners:
+        if runner is default:
+            default_indicator = " (default)"
+        else:
+            default_indicator = ""
+
+        flags.add_argument(
+            "--%s" % runner_name(runner),
+            help    = runner_help(runner) + default_indicator,
+            action  = "store_const",
+            const   = runner,
+            dest    = "__runner__",
+            default = argparse.SUPPRESS)
+
+
+def register_arguments(parser: ArgumentParser, runners: List, exec: List) -> None:
+    """
+    Register arguments shared by all runners as well as runner-specific
+    arguments on the given ArgumentParser instance.
+    """
+
+    # Unpack exec parameter into the command and everything else
+    (exec_cmd, *exec_args) = exec
+
+    # Arguments for all runners
+    development = parser.add_argument_group(
+        "development options",
+        "These should generally be unnecessary unless you're developing Nextstrain.")
+
+    # Program to execute
+    development.add_argument(
+        "--exec",
+        help    = "Program to run inside the build environment",
+        metavar = "<prog>",
+        default = exec_cmd)
+
+    # Static exec arguments; never modified by the user invocation
+    parser.set_defaults(exec_args = exec_args)
+
+    # Optional exec arguments, if the calling command indicates they're allowed
+    parser.set_defaults(extra_exec_args = [])
+
+    if ... in exec_args:
+        parser.add_argument(
+            "extra_exec_args",
+            help    = "Additional arguments to pass to the executed program",
+            metavar = "...",
+            nargs   = argparse.REMAINDER)
+
+    # Register additional arguments for each runner
+    for runner in runners:
+        runner.register_arguments(parser)
+
+
+def run(opts: Options) -> int:
+    """
+    Inspect the given options object and call the selected runner's run()
+    function with appropriate arguments.
+    """
+
+    # Construct the appropriate argv list so each runner doesn't have to.  This
+    # keeps together the definition of these options, above, and their
+    # handling, below.
+    argv = [
+        opts.exec,
+        *replace_ellipsis(opts.exec_args, opts.extra_exec_args)
+    ]
+
+    return opts.__runner__.run(opts, argv)
 
 
 def replace_ellipsis(items, elided_items):

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -44,6 +44,7 @@ def register_arguments(parser) -> None:
             metavar = "<dir>",
             action  = store_volume(name))
 
+    development.set_defaults(docker_args = [])
     development.add_argument(
         "--docker-arg",
         help    = "Additional arguments to pass to `docker run`",
@@ -67,9 +68,6 @@ def run(opts, argv, working_volume = None) -> int:
         for vol in missing_volumes:
             warn("    • %s: %s" % (vol.name, vol.src))
         return 1
-
-    if opts.docker_args is None:
-        opts.docker_args = []
 
     return exec_or_return([
         "docker", "run",

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import argparse
 import subprocess
+from .. import runner
 from ..util import warn, colored, capture_output
 from ..volume import store_volume
 
@@ -106,7 +107,7 @@ def run(opts):
         *opts.docker_args,
         opts.image,
         opts.exec,
-        *replace_ellipsis(opts.exec_args, opts.extra_exec_args)
+        *runner.replace_ellipsis(opts.exec_args, opts.extra_exec_args)
     ]
 
     try:
@@ -116,17 +117,6 @@ def run(opts):
         return e.returncode
     else:
         return 0
-
-
-def replace_ellipsis(items, elided_items):
-    """
-    Replaces any Ellipsis items (...) in a list, if any, with the items of a
-    second list.
-    """
-    return [
-        y for x in items
-          for y in (elided_items if x is ... else [x])
-    ]
 
 
 def test_setup():

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -5,7 +5,9 @@ Run commands inside a container image using Docker.
 import os
 import shutil
 import subprocess
+from typing import List
 from .. import runner
+from ..types import RunnerTestResults
 from ..util import warn, colored, capture_output, exec_or_return
 from ..volume import store_volume
 
@@ -14,7 +16,7 @@ DEFAULT_IMAGE = "nextstrain/base"
 COMPONENTS    = ["sacra", "fauna", "augur", "auspice"]
 
 
-def register_arguments(parser):
+def register_arguments(parser) -> None:
     # Docker development options
     development = parser.add_argument_group(
         "development options for --docker")
@@ -42,7 +44,7 @@ def register_arguments(parser):
         action  = "append")
 
 
-def run(opts, argv, working_volume = None):
+def run(opts, argv, working_volume = None) -> int:
     # Ensure all volume source paths exist.  Docker will auto-create missing
     # directories in the path, which, while desirable under some circumstances,
     # doesn't match up well with our use case.  We're aiming to not surprise or
@@ -91,7 +93,7 @@ def run(opts, argv, working_volume = None):
     ])
 
 
-def test_setup():
+def test_setup() -> RunnerTestResults:
     def test_run():
         try:
             status = subprocess.run(
@@ -111,7 +113,7 @@ def test_setup():
     ]
 
 
-def update():
+def update() -> bool:
     print(colored("bold", "Updating Docker image %s…" % DEFAULT_IMAGE))
     print()
 
@@ -145,7 +147,7 @@ def update():
     return True
 
 
-def dangling_images(name):
+def dangling_images(name: str) -> List[str]:
     """
     Return a list of Docker image IDs which are untagged ("dangling") and thus
     likely no longer in use.
@@ -164,12 +166,12 @@ def dangling_images(name):
     ])
 
 
-def print_version():
+def print_version() -> None:
     print_image_version()
     print_component_versions()
 
 
-def print_image_version():
+def print_image_version() -> None:
     """
     Print the Docker image name and version.
     """
@@ -196,7 +198,7 @@ def print_image_version():
     print("%s docker image %s" % (DEFAULT_IMAGE, image_ids[0] if image_ids else "not present"))
 
 
-def print_component_versions():
+def print_component_versions() -> None:
     """
     Print the git ids of the Nextstrain components in the image.
     """

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -42,7 +42,7 @@ def register_arguments(parser):
         action  = "append")
 
 
-def run(opts, argv):
+def run(opts, argv, working_volume = None):
     # Ensure all volume source paths exist.  Docker will auto-create missing
     # directories in the path, which, while desirable under some circumstances,
     # doesn't match up well with our use case.  We're aiming to not surprise or
@@ -77,6 +77,9 @@ def run(opts, argv):
       *["--volume=%s:/nextstrain/%s" % (v.src.resolve(), v.name)
             for v in opts.volumes
              if v.src is not None],
+
+        # Change the default working directory if requested
+        *(["--workdir=/nextstrain/%s" % working_volume.name] if working_volume else []),
 
         # Pass through credentials as environment variables
         "--env=RETHINK_HOST",

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -4,7 +4,6 @@ Run commands inside a container image using Docker.
 
 import os
 import shutil
-import argparse
 import subprocess
 from .. import runner
 from ..util import warn, colored, capture_output, exec_or_return
@@ -15,26 +14,16 @@ DEFAULT_IMAGE = "nextstrain/base"
 COMPONENTS    = ["sacra", "fauna", "augur", "auspice"]
 
 
-def register_arguments(parser, exec=None):
-    # Unpack exec parameter into the command and everything else
-    (exec_cmd, *exec_args) = exec
-
-    # Development options
+def register_arguments(parser):
+    # Docker development options
     development = parser.add_argument_group(
-        "development options",
-        "These should generally be unnecessary unless you're developing build images.")
+        "development options for --docker")
 
     development.add_argument(
         "--image",
         help    = "Container image in which to run the pathogen build",
         metavar = "<name>",
         default = DEFAULT_IMAGE)
-
-    development.add_argument(
-        "--exec",
-        help    = "Program to exec inside the build container",
-        metavar = "<prog>",
-        default = exec_cmd)
 
     development.set_defaults(volumes = [])
 
@@ -52,19 +41,8 @@ def register_arguments(parser, exec=None):
         dest    = "docker_args",
         action  = "append")
 
-    # Optional exec arguments
-    parser.set_defaults(exec_args = exec_args)
-    parser.set_defaults(extra_exec_args = [])
 
-    if ... in exec_args:
-        parser.add_argument(
-            "extra_exec_args",
-            help    = "Additional arguments to pass to the executed build program",
-            metavar = "...",
-            nargs   = argparse.REMAINDER)
-
-
-def run(opts):
+def run(opts, argv):
     # Ensure all volume source paths exist.  Docker will auto-create missing
     # directories in the path, which, while desirable under some circumstances,
     # doesn't match up well with our use case.  We're aiming to not surprise or
@@ -106,8 +84,7 @@ def run(opts):
 
         *opts.docker_args,
         opts.image,
-        opts.exec,
-        *runner.replace_ellipsis(opts.exec_args, opts.extra_exec_args)
+        *argv,
     ])
 
 

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -15,7 +15,7 @@ DEFAULT_IMAGE = "nextstrain/base"
 COMPONENTS    = ["sacra", "fauna", "augur", "auspice"]
 
 
-def register_arguments(parser, exec=None, volumes=[]):
+def register_arguments(parser, exec=None):
     # Unpack exec parameter into the command and everything else
     (exec_cmd, *exec_args) = exec
 
@@ -38,7 +38,7 @@ def register_arguments(parser, exec=None, volumes=[]):
 
     development.set_defaults(volumes = [])
 
-    for name in volumes:
+    for name in COMPONENTS:
         development.add_argument(
             "--" + name,
             help    = "Replace the image's copy of %s with a local copy" % name,

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -7,7 +7,7 @@ import shutil
 import argparse
 import subprocess
 from .. import runner
-from ..util import warn, colored, capture_output
+from ..util import warn, colored, capture_output, exec_or_return
 from ..volume import store_volume
 
 
@@ -83,7 +83,7 @@ def run(opts):
     if opts.docker_args is None:
         opts.docker_args = []
 
-    argv = [
+    return exec_or_return([
         "docker", "run",
         "--rm",             # Remove the ephemeral container after exiting
         "--tty",            # Colors, etc.
@@ -108,15 +108,7 @@ def run(opts):
         opts.image,
         opts.exec,
         *runner.replace_ellipsis(opts.exec_args, opts.extra_exec_args)
-    ]
-
-    try:
-        subprocess.run(argv, check = True)
-    except subprocess.CalledProcessError as e:
-        warn("Error running %s, exited %d" % (e.cmd, e.returncode))
-        return e.returncode
-    else:
-        return 0
+    ])
 
 
 def test_setup():

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -6,44 +6,12 @@ import os
 import shutil
 import argparse
 import subprocess
-from collections import namedtuple
-from pathlib import Path
 from ..util import warn, colored, capture_output
+from ..volume import store_volume
 
 
 DEFAULT_IMAGE = "nextstrain/base"
 COMPONENTS    = ["sacra", "fauna", "augur", "auspice"]
-
-
-def store_volume(volume_name):
-    """
-    Generates and returns an argparse.Action subclass for storing named volume
-    tuples.
-
-    Multiple argparse arguments can use this to cooperatively accept source
-    path definitions for named volumes.
-
-    Each named volume is stored as a namedtuple (name, src).  The tuple is
-    stored on the options object under the volume's name (modified to replace
-    slashes with underscores), as well as added to a shared list of volumes,
-    accessible via the "volumes" attribute on the options object.
-
-    For convenient path manipulation and testing, the "src" value is stored as
-    a Path object.
-    """
-    volume = namedtuple("volume", ("name", "src"))
-
-    class store(argparse.Action):
-        def __call__(self, parser, namespace, values, option_strings = None):
-            # Add the new volume to the list of volumes
-            volumes    = getattr(namespace, "volumes", [])
-            new_volume = volume(volume_name, Path(values))
-            setattr(namespace, "volumes", [*volumes, new_volume])
-
-            # Allow the new volume to be found by name on the opts object
-            setattr(namespace, volume_name.replace('/', '_'), new_volume)
-
-    return store
 
 
 def register_arguments(parser, exec=None, volumes=[]):

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -18,6 +18,14 @@ COMPONENTS    = ["sacra", "fauna", "augur", "auspice"]
 
 def register_arguments(parser) -> None:
     # Docker development options
+    #
+    # XXX TODO: Consider prefixing all of these with --docker-* at some point,
+    # depending on how other image-based runners (like Singularity) pan out.
+    # For now, I think it's better to do nothing than to prospectively rename.
+    # Renaming means maintaining the old names as deprecated alternatives for a
+    # while anyway, so we might as well just keep using what we have until
+    # we're forced to change.
+    #   -trs, 15 August 2018
     development = parser.add_argument_group(
         "development options for --docker")
 

--- a/nextstrain/cli/runner/native.py
+++ b/nextstrain/cli/runner/native.py
@@ -1,0 +1,51 @@
+"""
+Run commands on the native host, outside of any container image.
+"""
+
+import os
+import shutil
+from ..types import RunnerTestResults
+from ..util import exec_or_return
+
+
+def register_arguments(parser) -> None:
+    """
+    No-op.  No arguments necessary.
+    """
+    pass
+
+
+def run(opts, argv, working_volume = None) -> int:
+    if working_volume:
+        os.chdir(str(working_volume.src))
+
+    return exec_or_return(argv)
+
+
+def test_setup() -> RunnerTestResults:
+    return [
+        ('snakemake is installed',
+            shutil.which("snakemake") is not None),
+
+        ('augur is installed',
+            shutil.which("augur") is not None),
+
+        # XXX TODO: Test other programs here too.  auspice, for example, once
+        # it has a native entry point.
+        #   -trs, 31 July 2018
+    ]
+
+
+def update() -> bool:
+    """
+    No-op.  Updating the native environment isn't reasonably possible.
+    """
+    return True
+
+
+def print_version() -> None:
+    # XXX TODO: Show the versions of augur and auspice once those have
+    # command-line interfaces to printing their versions (and the versions of
+    # tools like mafft, FastTree, etc).
+    #   -trs, 17 August 2018
+    pass

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -1,0 +1,7 @@
+"""
+Type aliases for internal use.
+"""
+
+import argparse
+
+Options = argparse.Namespace

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -3,5 +3,9 @@ Type aliases for internal use.
 """
 
 import argparse
+from typing import List, Tuple
 
 Options = argparse.Namespace
+
+RunnerTestResult  = Tuple[str, bool]
+RunnerTestResults = List[RunnerTestResult]

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -6,6 +6,7 @@ from types import ModuleType
 from typing import List
 from pkg_resources import parse_version
 from sys import stderr
+from textwrap import dedent, indent
 from .__version__ import __version__
 
 
@@ -137,3 +138,16 @@ def module_basename(module: ModuleType, base_module: str = None) -> str:
         base_module = module.__package__
 
     return remove_prefix(base_module, module.__name__).lstrip(".")
+
+
+def format_usage(doc: str) -> str:
+    """
+    Reformat a multi-line description of command-line usage to play nice with
+    argparse's usage printing.
+
+    Strips trailing and leading newlines, removes indentation shared by all
+    lines (common in docstrings), and then pads all but the first line to match
+    the "usage: " prefix argparse prints for the first line.
+    """
+    padding = " " * len("usage: ")
+    return indent(dedent(doc.strip("\n")), padding).lstrip()

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -3,6 +3,7 @@ import re
 import requests
 import subprocess
 from types import ModuleType
+from typing import List
 from pkg_resources import parse_version
 from sys import stderr
 from .__version__ import __version__
@@ -94,7 +95,7 @@ def capture_output(argv):
     return result.stdout.decode("utf-8").splitlines()
 
 
-def exec_or_return(argv):
+def exec_or_return(argv: List[str]) -> int:
     """
     exec(3) into the desired program, or return 1 on failure.  Never returns if
     successful.
@@ -113,6 +114,16 @@ def runner_name(runner: ModuleType) -> str:
     Return a friendly name suitable for display for the given runner module.
     """
     return module_basename(runner).replace("_", "-")
+
+
+def runner_help(runner: ModuleType) -> str:
+    """
+    Return a brief description of a runner module, suitable for help strings.
+    """
+    if runner.__doc__:
+        return runner.__doc__.strip().splitlines()[0]
+    else:
+        return "(undocumented)"
 
 
 def module_basename(module: ModuleType, base_module: str = None) -> str:

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -1,6 +1,7 @@
 import re
 import requests
 import subprocess
+from types import ModuleType
 from pkg_resources import parse_version
 from sys import stderr
 from .__version__ import __version__
@@ -90,3 +91,23 @@ def capture_output(argv):
         check  = True)
 
     return result.stdout.decode("utf-8").splitlines()
+
+
+def runner_name(runner: ModuleType) -> str:
+    """
+    Return a friendly name suitable for display for the given runner module.
+    """
+    return module_basename(runner).replace("_", "-")
+
+
+def module_basename(module: ModuleType, base_module: str = None) -> str:
+    """
+    Return the final portion of the given module's name, akin to a file's basename.
+
+    Defaults to returning the portion after the name of the module's containing
+    package, but this may be changed by providing the base_module parameter.
+    """
+    if not base_module:
+        base_module = module.__package__
+
+    return remove_prefix(base_module, module.__name__).lstrip(".")

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -1,3 +1,4 @@
+import os
 import re
 import requests
 import subprocess
@@ -91,6 +92,20 @@ def capture_output(argv):
         check  = True)
 
     return result.stdout.decode("utf-8").splitlines()
+
+
+def exec_or_return(argv):
+    """
+    exec(3) into the desired program, or return 1 on failure.  Never returns if
+    successful.
+
+    The return value makes this suitable for chaining through to sys.exit().
+    """
+    try:
+        os.execvp(argv[0], argv)
+    except OSError as error:
+        warn("Error executing into %s: %s" % (argv, error))
+        return 1
 
 
 def runner_name(runner: ModuleType) -> str:

--- a/nextstrain/cli/volume.py
+++ b/nextstrain/cli/volume.py
@@ -1,0 +1,39 @@
+"""
+Volumes map well-known names to a source path.
+"""
+
+import argparse
+from collections import namedtuple
+from pathlib import Path
+
+
+NamedVolume = namedtuple("NamedVolume", ("name", "src"))
+
+
+def store_volume(volume_name):
+    """
+    Generates and returns an argparse.Action subclass for storing named volume
+    tuples.
+
+    Multiple argparse arguments can use this to cooperatively accept source
+    path definitions for named volumes.
+
+    Each named volume is stored as a namedtuple (name, src).  The tuple is
+    stored on the options object under the volume's name (modified to replace
+    slashes with underscores), as well as added to a shared list of volumes,
+    accessible via the "volumes" attribute on the options object.
+
+    For convenient path manipulation and testing, the "src" value is stored as
+    a Path object.
+    """
+    class store(argparse.Action):
+        def __call__(self, parser, namespace, values, option_strings = None):
+            # Add the new volume to the list of volumes
+            volumes    = getattr(namespace, "volumes", [])
+            new_volume = NamedVolume(volume_name, Path(values))
+            setattr(namespace, "volumes", [*volumes, new_volume])
+
+            # Allow the new volume to be found by name on the opts object
+            setattr(namespace, volume_name.replace('/', '_'), new_volume)
+
+    return store


### PR DESCRIPTION
This PR adds support for `nextstrain build --native …` which runs the build outside of the container image.  Support for this is on my roadmap to AWS Batch builds, but it's also nice to just provide a consistent interface for running builds under different environments.

Several related refactorings and improvements to help messaging were driven by the `--native` addition (with an eye on supporting more runners soon), and those are included as separate commits bookending `--native`.  I recommend reviewing commit-by-commit from the start rather than the PR as a whole, as the story will be clearer.