### PR TITLE
Pull down new Docker images by their build-* tag

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -146,8 +146,10 @@ def update() -> bool:
                 ["docker", "image", "rm", *images],
                 check = True)
     except subprocess.CalledProcessError as error:
-        warn("Error pruning old image versions: ", error)
-        return False
+        warn()
+        warn("Update succeeded, but an error occurred pruning old image versions:")
+        warn("  ", error)
+        warn()
 
     return True
 

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -156,8 +156,8 @@ def update() -> bool:
 
 def dangling_images(name: str) -> List[str]:
     """
-    Return a list of Docker image IDs which are untagged ("dangling") and thus
-    likely no longer in use.
+    Return a list of local Docker image IDs which are untagged ("dangling") and
+    thus likely no longer in use.
 
     Since dangling images are untagged, this finds images by name using our
     custom org.nextstrain.image.name label.


### PR DESCRIPTION
Instead of tracking the mutable `latest` tag, `nextstrain update` now looks up the latest image with a `build-*` tag and downloads that.  Our build tags are, most importantly, not updated after creation and thus are suitable references for reproducible runs.  The same is not true of `latest`.  For example, the output of `nextstrain version --verbose` now includes the specific build tag.

Old images tagged with `build-*` are considered dangling and are removed locally during the pruning process after update.

The current image in use is saved in the config file so that subsequent `nextstrain build` runs can look it up there.  Only `nextstrain update` will bump the image version, preserving that existing behaviour.

Setting the config file value to an image tagged something other than `latest` or `build-*` tag will cause it to be preserved as-is, under the assumption that it is some other mutable tag that updates in-place. This works well for our `branch-*` tags, for example, and gracefully handles forks of the nextstrain/base image too.
