### PR TITLE
Run snakemake with '-p' flag to print commands

### DIFF
--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -48,7 +48,7 @@ def register_parser(subparser):
         action  = store_volume("build"))
 
     # Register runner flags and arguments
-    runner.register_runners(parser, exec = ["snakemake", ...])
+    runner.register_runners(parser, exec = ["snakemake", "-p", ...])
 
     return parser
 

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -48,7 +48,7 @@ def register_parser(subparser):
         action  = store_volume("build"))
 
     # Register runner flags and arguments
-    runner.register_runners(parser, exec = ["snakemake", "-p", ...])
+    runner.register_runners(parser, exec = ["snakemake", "--printshellcmds", ...])
 
     return parser
 


### PR DESCRIPTION
Running as `snakemake -p` causes snakemake to print shell commands run. I think this is generally useful to see what's going on and I run all local snakemake calls with `-p`.