### PR TITLE
Keep zipped S3 file and CloudWatch logs

### DIFF
--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -169,21 +169,17 @@ def run(opts, argv, working_volume = None) -> int:
         s3.download_workdir(remote_workdir, local_workdir)
 
 
-    # Remove remote results.
-    print_stage("Cleaning up S3")
-
-    remote_workdir.delete()
-
-    print("deleted:", s3.object_url(remote_workdir))
+    # Don't remove remote results
+    # print_stage("Cleaning up S3")
+    # remote_workdir.delete()
+    # print("deleted:", s3.object_url(remote_workdir))
 
 
-    # Remove log stream.
-    if job.log_stream:
-        print_stage("Cleaning up logs")
-
-        logs.delete_stream(job.log_stream)
-
-        print("deleted log stream:", job.log_stream)
+    # Don't remove log stream
+    # if job.log_stream:
+    #     print_stage("Cleaning up logs")
+    #     logs.delete_stream(job.log_stream)
+    #     print("deleted log stream:", job.log_stream)
 
 
     # Exit with the job's exit code, or assume success


### PR DESCRIPTION
When running a series of `--aws-batch` jobs if one would fail, then I couldn't review logs, which was frustrating. Also, when running a series of `--aws-batch` jobs, I would often want the ability to redownload zipped file from S3. Rather than deleting on download, I think better to add an automatic removal of old files from the nextstrain-jobs bucket.