### PR TITLE
runner.aws_batch: Specify requested vCPU and memory

### DIFF
--- a/doc/aws-batch.md
+++ b/doc/aws-batch.md
@@ -24,6 +24,13 @@ directory.
 [AWS Batch]: https://aws.amazon.com/batch/
 [`zika-tutorial/` directory]: https://github.com/nextstrain/zika-tutorial
 
+### Requesting resources
+
+By default AWS Batch jobs request 4 vCPUs and 7200MB of memory. Generally, when
+running Snamemake, the `--jobs` option should be matched to the requested number
+of vCPUs. These defaults can be overridden by specifying `--aws-batch-cpus` and
+`--aws-batch-memory`, for instance `--aws-batch-cpus=8` and
+`--aws-batch-memory=14800`.
 
 ## Configuration on your computer
 
@@ -75,7 +82,6 @@ or in the `~/.nextstrain/config` file
     s3-bucket = ...
 
 or passing the `--aws-batch-s3-bucket=...` option to `nextstrain build`.
-
 
 # Setting up AWS to run Nextstrain builds
 

--- a/doc/aws-batch.md
+++ b/doc/aws-batch.md
@@ -27,10 +27,20 @@ directory.
 ### Requesting resources
 
 By default AWS Batch jobs request 4 vCPUs and 7200MB of memory. Generally, when
-running Snamemake, the `--jobs` option should be matched to the requested number
+running Snakemake, the `--jobs` option should be matched to the requested number
 of vCPUs. These defaults can be overridden by specifying `--aws-batch-cpus` and
 `--aws-batch-memory`, for instance `--aws-batch-cpus=8` and
-`--aws-batch-memory=14800`.
+`--aws-batch-memory=14800`. Alternatively, request can be specified in the
+`~/.nextstrain/config` file via
+
+    [aws-batch]
+    cpus = ...
+    memory = ...
+
+Or via setting environment variables `NEXTSTRAIN_AWS_BATCH_CPUS` and
+`NEXTSTRAIN_AWS_BATCH_MEMORY`. Note that requesting more CPUs or memory than
+available in a compute environment will result in a job that is queued but
+is never started.
 
 ## Configuration on your computer
 

--- a/doc/aws-batch.md
+++ b/doc/aws-batch.md
@@ -24,23 +24,32 @@ directory.
 [AWS Batch]: https://aws.amazon.com/batch/
 [`zika-tutorial/` directory]: https://github.com/nextstrain/zika-tutorial
 
-### Requesting resources
+### Using and requesting resources
 
-By default AWS Batch jobs request 4 vCPUs and 7200MB of memory. Generally, when
-running Snakemake, the `--jobs` option should be matched to the requested number
-of vCPUs. These defaults can be overridden by specifying `--aws-batch-cpus` and
-`--aws-batch-memory`, for instance `--aws-batch-cpus=8` and
-`--aws-batch-memory=14800`. Alternatively, request can be specified in the
-`~/.nextstrain/config` file via
+By default, each AWS Batch job will have available to it the number of vCPUs
+and amount of memory configured in your [job definition](#job-definition).  To
+take full advantage of multiple CPUs available, [Snakemake's `--jobs` (or
+`-j`)](https://snakemake.readthedocs.io/en/stable/executable.html#EXECUTION)
+option should generally be matched to the configured number of vCPUs.
+
+The resources configured in the job definition can be overridden on a per-build
+basis using the `--aws-batch-cpus` and/or `--aws-batch-memory` options, for
+example:
+
+    nextstrain build --aws-batch --aws-batch-cpus=8 --aws-batch-memory=14800 zika-tutorial/ --jobs 8
+
+Alternatively, default resource overrides can be set via the
+`~/.nextstrain/config` file:
 
     [aws-batch]
     cpus = ...
     memory = ...
 
-Or via setting environment variables `NEXTSTRAIN_AWS_BATCH_CPUS` and
-`NEXTSTRAIN_AWS_BATCH_MEMORY`. Note that requesting more CPUs or memory than
-available in a compute environment will result in a job that is queued but
-is never started.
+Or via the environment variables `NEXTSTRAIN_AWS_BATCH_CPUS` and
+`NEXTSTRAIN_AWS_BATCH_MEMORY`.
+
+Note that requesting more CPUs or memory than available in a compute
+environment will result in a job that is queued but is never started.
 
 ## Configuration on your computer
 

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -26,6 +26,13 @@ DEFAULT_S3_BUCKET = os.environ.get("NEXTSTRAIN_AWS_BATCH_S3_BUCKET") \
                  or config.get("aws-batch", "s3-bucket") \
                  or "nextstrain-jobs"
 
+DEFAULT_CPUS = os.environ.get("NEXTSTRAIN_AWS_CPUS") \
+            or config.get("aws-batch", "cpus") \
+            or "4"
+
+DEFAULT_MEMORY = os.environ.get("NEXTSTRAIN_AWS_MEMORY") \
+              or config.get("aws-batch", "memory") \
+              or "7400"
 
 def register_arguments(parser) -> None:
     # AWS Batch development options
@@ -53,6 +60,20 @@ def register_arguments(parser) -> None:
         help    = "Name of the AWS S3 bucket to use as shared storage",
         metavar = "<name>",
         default = DEFAULT_S3_BUCKET)
+
+    development.add_argument(
+        "--aws-batch-cpus",
+        dest    = "cpus",
+        help    = "Number of vCPUs to request for job",
+        metavar = "<name>",
+        default = DEFAULT_CPUS)
+
+    development.add_argument(
+        "--aws-batch-memory",
+        dest    = "memory",
+        help    = "Amount of memory in MB to request for job",
+        metavar = "<name>",
+        default = DEFAULT_MEMORY)
 
 
 def run(opts, argv, working_volume = None) -> int:
@@ -83,6 +104,8 @@ def run(opts, argv, working_volume = None) -> int:
             name       = run_id,
             queue      = opts.job_queue,
             definition = opts.job_definition,
+            cpus = int(opts.cpus),
+            memory = int(opts.memory),
             workdir    = remote_workdir,
             exec       = argv)
     except Exception as error:

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -26,13 +26,13 @@ DEFAULT_S3_BUCKET = os.environ.get("NEXTSTRAIN_AWS_BATCH_S3_BUCKET") \
                  or config.get("aws-batch", "s3-bucket") \
                  or "nextstrain-jobs"
 
-DEFAULT_CPUS = os.environ.get("NEXTSTRAIN_AWS_CPUS") \
-            or config.get("aws-batch", "cpus") \
-            or "4"
+# defaults to None if enviroment or config is not set
+DEFAULT_CPUS = os.environ.get("NEXTSTRAIN_AWS_BATCH_CPUS") \
+            or config.get("aws-batch", "cpus")
 
-DEFAULT_MEMORY = os.environ.get("NEXTSTRAIN_AWS_MEMORY") \
-              or config.get("aws-batch", "memory") \
-              or "7400"
+# defaults to None if enviroment or config is not set
+DEFAULT_MEMORY = os.environ.get("NEXTSTRAIN_AWS_BATCH_MEMORY") \
+              or config.get("aws-batch", "memory")
 
 def register_arguments(parser) -> None:
     # AWS Batch development options
@@ -65,14 +65,16 @@ def register_arguments(parser) -> None:
         "--aws-batch-cpus",
         dest    = "cpus",
         help    = "Number of vCPUs to request for job",
-        metavar = "<name>",
+        metavar = "<count>",
+        type    = int,
         default = DEFAULT_CPUS)
 
     development.add_argument(
         "--aws-batch-memory",
         dest    = "memory",
         help    = "Amount of memory in MB to request for job",
-        metavar = "<name>",
+        metavar = "<megabytes>",
+        type    = int,
         default = DEFAULT_MEMORY)
 
 
@@ -104,8 +106,8 @@ def run(opts, argv, working_volume = None) -> int:
             name       = run_id,
             queue      = opts.job_queue,
             definition = opts.job_definition,
-            cpus = int(opts.cpus),
-            memory = int(opts.memory),
+            cpus       = opts.cpus,
+            memory     = opts.memory,
             workdir    = remote_workdir,
             exec       = argv)
     except Exception as error:

--- a/nextstrain/cli/runner/aws_batch/jobs.py
+++ b/nextstrain/cli/runner/aws_batch/jobs.py
@@ -142,8 +142,8 @@ def submit(name: str,
                 },
                 *forwarded_environment(),
             ],
-            "vcpus": cpus,
-            "memory": memory,
+            **({ "vcpus": cpus } if cpus else {}),
+            **({ "memory": memory } if memory else {}),
             "command": [
                 "/sbin/entrypoint-aws-batch",
                 *exec

--- a/nextstrain/cli/runner/aws_batch/jobs.py
+++ b/nextstrain/cli/runner/aws_batch/jobs.py
@@ -119,6 +119,8 @@ class JobState:
 def submit(name: str,
            queue: str,
            definition: str,
+           cpus: int,
+           memory: int,
            workdir: s3.S3Object,
            exec: Iterable[str]) -> JobState:
     """
@@ -140,6 +142,8 @@ def submit(name: str,
                 },
                 *forwarded_environment(),
             ],
+            "vcpus": cpus,
+            "memory": memory,
             "command": [
                 "/sbin/entrypoint-aws-batch",
                 *exec

--- a/nextstrain/cli/runner/aws_batch/jobs.py
+++ b/nextstrain/cli/runner/aws_batch/jobs.py
@@ -119,8 +119,8 @@ class JobState:
 def submit(name: str,
            queue: str,
            definition: str,
-           cpus: int,
-           memory: int,
+           cpus: Optional[int],
+           memory: Optional[int],
            workdir: s3.S3Object,
            exec: Iterable[str]) -> JobState:
     """


### PR DESCRIPTION
This passes `--aws-batch-cpus` and `--aws-batch-memory` to `containerOverrides`. This also moves defaults to the CLI instead of AWS config.

This has been tested and appears to work just fine.

Resolves #42.