### PR TITLE
Default environment (runner) with `check-setup --set-default`

### DIFF
--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -19,6 +19,7 @@ Three environments are supported, each of which will be tested:
 
 from functools import partial
 from textwrap import indent
+from .. import config
 from ..types import Options
 from ..util import colored, check_for_new_version, remove_prefix, runner_name
 from ..runner import all_runners
@@ -26,6 +27,12 @@ from ..runner import all_runners
 
 def register_parser(subparser):
     parser = subparser.add_parser("check-setup", help = "Test your local setup")
+
+    parser.add_argument(
+        "--set-default",
+        help   = "Set the default environment to use going forward based on the results of checking your setup",
+        action = "store_true")
+
     return parser
 
 
@@ -94,6 +101,10 @@ def run(opts: Options) -> int:
 
     if supported_runners:
         print("Supported Nextstrain environments:", ", ".join(map(success, supported_runners)))
+
+        if opts.set_default:
+            print("Setting default environment to %s" % supported_runners[0])
+            config.set("core", "runner", supported_runners[0])
     else:
         print(failure("No support for any Nextstrain environment"))
 


### PR DESCRIPTION
@alliblk When you get a a chance tomorrow, would you test out this `default-runner` branch? You should be able to run `./bin/nextstrain check-setup --set-default` and see output at the bottom like:

    Setting default environment to docker

If docker support isn't found but native is, it should say "native" instead.

It'd be great to test it on the Windows machine, but one way to also test this out on your Mac is by stopping Docker using its menu in the Mac menu bar. Once a default is set, you should be able to run commands like `nextstrain build` and `nextstrain view` without specifying any runner/environment. You should also see the command's `--help` output mention which of `--docker` or `--native` is the default.