### PR TITLE
File management commands (upload, download, list, delete)

### DIFF
--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -8,8 +8,8 @@ import argparse
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter
 from types    import SimpleNamespace
 
+from .argparse    import register_commands, register_default_command
 from .command     import build, view, deploy, shell, update, check_setup, version
-from .util        import format_usage
 from .__version__ import __version__
 
 
@@ -49,40 +49,6 @@ def run(args):
 
     opts = parser.parse_args(args)
     return opts.__command__.run(opts)
-
-
-def register_default_command(parser):
-    """
-    Sets the default command to run when none is provided.
-    """
-    def run(x):
-        parser.print_help()
-        return 2
-
-    # Using a namespace object to mock a module with a run() function
-    parser.set_defaults( __command__ = SimpleNamespace(run = run) )
-
-
-def register_commands(parser, commands):
-    """
-    Lets each command module register a subparser.
-    """
-    subparsers = parser.add_subparsers(title = "commands")
-
-    for cmd in commands:
-        subparser = cmd.register_parser(subparsers)
-        subparser.set_defaults( __command__ = cmd )
-
-        # Ensure all subparsers format like the top-level parser
-        subparser.formatter_class = parser.formatter_class
-
-        # Default usage message to the docstring of register_parser()
-        if not subparser.usage and cmd.register_parser.__doc__:
-            subparser.usage = format_usage(cmd.register_parser.__doc__)
-
-        # Default long description to the docstring of the command
-        if not subparser.description and cmd.__doc__:
-            subparser.description = cmd.__doc__
 
 
 def register_version_alias(parser):

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -10,6 +10,8 @@ from types    import SimpleNamespace
 
 from .argparse    import register_commands, register_default_command
 from .command     import build, view, deploy, remote, shell, update, check_setup, version
+from .errors      import NextstrainCliError
+from .util        import warn
 from .__version__ import __version__
 
 
@@ -49,7 +51,13 @@ def run(args):
     register_version_alias(parser)
 
     opts = parser.parse_args(args)
-    return opts.__command__.run(opts)
+
+    try:
+        return opts.__command__.run(opts)
+
+    except NextstrainCliError as error:
+        warn(error)
+        return 1
 
 
 def register_version_alias(parser):

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, RawDescripti
 from types    import SimpleNamespace
 
 from .argparse    import register_commands, register_default_command
-from .command     import build, view, deploy, shell, update, check_setup, version
+from .command     import build, view, deploy, remote, shell, update, check_setup, version
 from .__version__ import __version__
 
 
@@ -37,6 +37,7 @@ def run(args):
         build,
         view,
         deploy,
+        remote,
         shell,
         update,
         check_setup,

--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -41,6 +41,15 @@ def register_commands(parser, commands):
         if not subparser.description and cmd.__doc__:
             subparser.description = cmd.__doc__
 
+        # Recursively register any subcommands
+        if getattr(subparser, "subcommands", None):
+            register_commands(subparser, subparser.subcommands)
+
+            # If a command with subcommands doesn't have its own run()
+            # function, then print its help when called without a subcommand.
+            if not getattr(cmd, "run", None):
+                register_default_command(subparser)
+
 
 def add_extended_help_flags(parser):
     """

--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -4,6 +4,42 @@ Custom helpers for extending the behaviour of argparse standard library.
 
 from argparse import Action, SUPPRESS
 from itertools import takewhile
+from types import SimpleNamespace
+from .util import format_usage
+
+
+def register_default_command(parser):
+    """
+    Sets the default command to run when none is provided.
+    """
+    def run(x):
+        parser.print_help()
+        return 2
+
+    # Using a namespace object to mock a module with a run() function
+    parser.set_defaults( __command__ = SimpleNamespace(run = run) )
+
+
+def register_commands(parser, commands):
+    """
+    Lets each command module register a subparser.
+    """
+    subparsers = parser.add_subparsers(title = "commands")
+
+    for cmd in commands:
+        subparser = cmd.register_parser(subparsers)
+        subparser.set_defaults( __command__ = cmd )
+
+        # Ensure all subparsers format like the top-level parser
+        subparser.formatter_class = parser.formatter_class
+
+        # Default usage message to the docstring of register_parser()
+        if not subparser.usage and cmd.register_parser.__doc__:
+            subparser.usage = format_usage(cmd.register_parser.__doc__)
+
+        # Default long description to the docstring of the command
+        if not subparser.description and cmd.__doc__:
+            subparser.description = cmd.__doc__
 
 
 def add_extended_help_flags(parser):

--- a/nextstrain/cli/command/deploy.py
+++ b/nextstrain/cli/command/deploy.py
@@ -4,9 +4,20 @@
 # Registering our own parser lets us preserve the original short description
 # and avoids introducing "upload" as a top-level command.
 
+from textwrap import dedent
 from .remote.upload import register_arguments, run, __doc__
 
 def register_parser(subparser):
     parser = subparser.add_parser("deploy", help = "Deploy pathogen build")
     register_arguments(parser)
     return parser
+
+def insert_paragraph(text, index, insert):
+    paras = text.split("\n\n")
+    paras.insert(index, dedent(insert))
+    return "\n\n".join(paras)
+
+__doc__ = insert_paragraph(
+    __doc__, 1, """
+    The `nextstrain deploy` command is an alias for `nextstrain remote upload`.
+    """)

--- a/nextstrain/cli/command/deploy.py
+++ b/nextstrain/cli/command/deploy.py
@@ -1,87 +1,12 @@
-"""
-Deploys a set of built pathogen JSON data files or Markdown narratives to a
-remote location.
+# This command, `nextstrain deploy`, is now an alias for `nextstrain remote
+# upload`.
+#
+# Registering our own parser lets us preserve the original short description
+# and avoids introducing "upload" as a top-level command.
 
-nextstrain.org, or standalone instances of Auspice, fetch the deployed JSON
-data files or Markdown narratives for display.
- 
- 
-Destinations
-------------
-
-Currently only Amazon S3 buckets (s3://…) are supported as the remote
-destination, but others can be added in the future.
-
-Destination URLs support optional path prefixes if you want your local
-filenames to be prefixed on the remote destination.  For example:
-
-    nextstrain deploy s3://my-bucket/some/prefix/ auspice/zika*.json
-
-will upload files named "some/prefix/zika*.json".
- 
- 
-Authentication
---------------
-
-Credentials for authentication should generally be provided by environment
-variables specific to each destination type.
-
-S3
---
-
-* AWS_ACCESS_KEY_ID
-* AWS_SECRET_ACCESS_KEY
-
-More information at:
-
-    https://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables
-
-A persistent credentials file, ~/.aws/credentials, is also supported:
-
-    https://boto3.readthedocs.io/en/latest/guide/configuration.html#shared-credentials-file
- 
-"""
-
-from pathlib import Path
-from urllib.parse import urlparse
-from ..util import warn
-from ..remote import s3
-
-
-SUPPORTED_SCHEMES = {
-    "s3": s3,
-}
-
+from .remote.upload import register_arguments, run, __doc__
 
 def register_parser(subparser):
     parser = subparser.add_parser("deploy", help = "Deploy pathogen build")
-
-    # Destination
-    parser.add_argument(
-        "destination",
-        help    = "Deploy destination as a URL, with optional key/path prefix",
-        metavar = "<s3://bucket-name>")
-
-    # Files to deploy
-    parser.add_argument(
-        "files",
-        help    = "Files to deploy (e.g. JSON data files)",
-        metavar = "<file.json>",
-        nargs   = "+")
-
+    register_arguments(parser)
     return parser
-
-
-def run(opts):
-    url = urlparse(opts.destination)
-
-    if url.scheme not in SUPPORTED_SCHEMES:
-        warn("Error: Unsupported destination scheme %s://" % url.scheme)
-        warn("")
-        warn("Supported schemes are: %s" % ", ".join(SUPPORTED_SCHEMES))
-        return 1
-
-    remote = SUPPORTED_SCHEMES[url.scheme]
-    files  = [Path(f) for f in opts.files]
-
-    return remote.deploy(url, files)

--- a/nextstrain/cli/command/deploy.py
+++ b/nextstrain/cli/command/deploy.py
@@ -45,7 +45,7 @@ A persistent credentials file, ~/.aws/credentials, is also supported:
 from pathlib import Path
 from urllib.parse import urlparse
 from ..util import warn
-from ..deploy import s3
+from ..remote import s3
 
 
 SUPPORTED_SCHEMES = {
@@ -81,7 +81,7 @@ def run(opts):
         warn("Supported schemes are: %s" % ", ".join(SUPPORTED_SCHEMES))
         return 1
 
-    deploy = SUPPORTED_SCHEMES[url.scheme]
+    remote = SUPPORTED_SCHEMES[url.scheme]
     files  = [Path(f) for f in opts.files]
 
-    return deploy.run(url, files)
+    return remote.deploy(url, files)

--- a/nextstrain/cli/command/deploy.py
+++ b/nextstrain/cli/command/deploy.py
@@ -2,8 +2,8 @@
 Deploys a set of built pathogen JSON data files or Markdown narratives to a
 remote location.
 
-nextstrain.org, or other instances of the Nextstrain web frontend (auspice),
-fetch the deployed JSON data files or Markdown narratives for display.
+nextstrain.org, or standalone instances of Auspice, fetch the deployed JSON
+data files or Markdown narratives for display.
  
  
 Destinations

--- a/nextstrain/cli/command/remote/__init__.py
+++ b/nextstrain/cli/command/remote/__init__.py
@@ -29,7 +29,7 @@ A persistent credentials file, ~/.aws/credentials, is also supported:
 __shortdoc__ = __doc__.strip().splitlines()[0]
 
 
-from . import upload, download, ls
+from . import upload, download, ls, delete
 
 
 def register_parser(subparser):
@@ -39,6 +39,7 @@ def register_parser(subparser):
         upload,
         download,
         ls,
+        delete,
     ]
 
     return parser

--- a/nextstrain/cli/command/remote/__init__.py
+++ b/nextstrain/cli/command/remote/__init__.py
@@ -29,7 +29,7 @@ A persistent credentials file, ~/.aws/credentials, is also supported:
 __shortdoc__ = __doc__.strip().splitlines()[0]
 
 
-from . import upload
+from . import upload, download
 
 
 def register_parser(subparser):
@@ -37,6 +37,7 @@ def register_parser(subparser):
 
     parser.subcommands = [
         upload,
+        download,
     ]
 
     return parser

--- a/nextstrain/cli/command/remote/__init__.py
+++ b/nextstrain/cli/command/remote/__init__.py
@@ -29,7 +29,7 @@ A persistent credentials file, ~/.aws/credentials, is also supported:
 __shortdoc__ = __doc__.strip().splitlines()[0]
 
 
-from . import upload, download
+from . import upload, download, ls
 
 
 def register_parser(subparser):
@@ -38,6 +38,7 @@ def register_parser(subparser):
     parser.subcommands = [
         upload,
         download,
+        ls,
     ]
 
     return parser

--- a/nextstrain/cli/command/remote/__init__.py
+++ b/nextstrain/cli/command/remote/__init__.py
@@ -1,0 +1,42 @@
+"""
+Upload, download, and manage Nextstrain files on remote sources.
+
+Remote sources host the Auspice JSON data files and Markdown narratives that
+are fetched by nextstrain.org or standalone instances of Auspice.
+ 
+Currently only Amazon S3 buckets (s3://…) are supported as the remote
+source, but others can be added in the future.
+
+Credentials for authentication should generally be provided by environment
+variables specific to each source.
+
+Amazon S3
+---------
+
+* AWS_ACCESS_KEY_ID
+* AWS_SECRET_ACCESS_KEY
+
+More information at:
+
+    https://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables
+
+A persistent credentials file, ~/.aws/credentials, is also supported:
+
+    https://boto3.readthedocs.io/en/latest/guide/configuration.html#shared-credentials-file
+ 
+"""
+
+__shortdoc__ = __doc__.strip().splitlines()[0]
+
+
+from . import upload
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser("remote", help = __shortdoc__)
+
+    parser.subcommands = [
+        upload,
+    ]
+
+    return parser

--- a/nextstrain/cli/command/remote/delete.py
+++ b/nextstrain/cli/command/remote/delete.py
@@ -44,4 +44,15 @@ def run(opts):
 
     remote = SUPPORTED_SCHEMES[url.scheme]
 
-    return remote.delete(url, recursively = opts.recursively)
+    deleted, errors = remote.delete(url, recursively = opts.recursively)
+
+    for file in deleted:
+        print("deleted: %s" % file)
+
+    for file, *details in errors:
+        warn('failed to delete "%s": %s' % (file, details))
+
+    if not deleted:
+        warn("Nothing deleted!")
+
+    return 0 if deleted and not errors else 1

--- a/nextstrain/cli/command/remote/delete.py
+++ b/nextstrain/cli/command/remote/delete.py
@@ -1,0 +1,47 @@
+"""
+Delete pathogen JSON data files or Markdown narratives from a remote source.
+
+See `nextstrain remote --help` for more information on remote sources.
+"""
+
+from urllib.parse import urlparse
+from ...remote import s3
+from ...util import warn
+
+
+SUPPORTED_SCHEMES = {
+    "s3": s3,
+}
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser(
+        "delete",
+        aliases = ["rm"],
+        help    = "Delete dataset and narrative files")
+
+    parser.add_argument(
+        "remote_path",
+        help    = "Remote path as a URL",
+        metavar = "<s3://bucket-name>")
+
+    parser.add_argument(
+        "--recursively", "-r",
+        help   = "Delete files recursively under the given path prefix",
+        action = "store_true")
+
+    return parser
+
+
+def run(opts):
+    url = urlparse(opts.remote_path)
+
+    if url.scheme not in SUPPORTED_SCHEMES:
+        warn("Error: Unsupported remote scheme %s://" % url.scheme)
+        warn("")
+        warn("Supported schemes are: %s" % ", ".join(SUPPORTED_SCHEMES))
+        return 1
+
+    remote = SUPPORTED_SCHEMES[url.scheme]
+
+    return remote.delete(url, recursively = opts.recursively)

--- a/nextstrain/cli/command/remote/delete.py
+++ b/nextstrain/cli/command/remote/delete.py
@@ -44,15 +44,15 @@ def run(opts):
 
     remote = SUPPORTED_SCHEMES[url.scheme]
 
-    deleted, errors = remote.delete(url, recursively = opts.recursively)
+    deleted = remote.delete(url, recursively = opts.recursively)
+    deleted_count = 0
 
     for file in deleted:
         print("deleted: %s" % file)
+        deleted_count += 1
 
-    for file, *details in errors:
-        warn('failed to delete "%s": %s' % (file, details))
-
-    if not deleted:
+    if deleted_count:
+        return 0
+    else:
         warn("Nothing deleted!")
-
-    return 0 if deleted and not errors else 1
+        return 1

--- a/nextstrain/cli/command/remote/download.py
+++ b/nextstrain/cli/command/remote/download.py
@@ -1,0 +1,71 @@
+"""
+Downloads pathogen JSON data files or Markdown narratives from a remote
+source.
+ 
+Source URLs specify the file(s) to download:
+
+    nextstrain remote download s3://my-bucket/some/prefix/data.json
+
+will download "data.json" into the current directory.
+
+Recursive downloads are supported for downloading multiple files:
+
+    nextstrain remote download --recursive s3://my-bucket/some/prefix/
+
+will download all files under "some/prefix/" into the current directory.
+
+See `nextstrain remote --help` for more information on remote sources.
+"""
+
+from pathlib import Path
+from urllib.parse import urlparse
+from ...remote import s3
+from ...util import warn
+
+
+SUPPORTED_SCHEMES = {
+    "s3": s3,
+}
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser("download", help = "Download dataset and narrative files")
+
+    parser.add_argument(
+        "remote_path",
+        help    = "Remote file path as a URL",
+        metavar = "<s3://bucket-name>")
+
+    parser.add_argument(
+        "local_path",
+        help    = "Local directory to save files in.  "
+                  "May be a local filename to use if the remote path points to a single file.",
+        metavar = "<path>",
+        type    = Path,
+        nargs   = "?",
+        default = ".")
+
+    parser.add_argument(
+        "--recursively", "-r",
+        help   = "Download all files with the given remote path prefix",
+        action = "store_true")
+
+    return parser
+
+
+def run(opts):
+    url = urlparse(opts.remote_path)
+
+    if url.scheme not in SUPPORTED_SCHEMES:
+        warn("Error: Unsupported remote scheme %s://" % url.scheme)
+        warn("")
+        warn("Supported schemes are: %s" % ", ".join(SUPPORTED_SCHEMES))
+        return 1
+
+    remote = SUPPORTED_SCHEMES[url.scheme]
+
+    if opts.recursively and not opts.local_path.is_dir():
+        warn("Local path must be a directory when using --recursively; «%s» is not" % opts.local_path)
+        return 1
+
+    return remote.download(url, opts.local_path, recursively = opts.recursively)

--- a/nextstrain/cli/command/remote/download.py
+++ b/nextstrain/cli/command/remote/download.py
@@ -68,4 +68,9 @@ def run(opts):
         warn("Local path must be a directory when using --recursively; «%s» is not" % opts.local_path)
         return 1
 
-    return remote.download(url, opts.local_path, recursively = opts.recursively)
+    downloads = remote.download(url, opts.local_path, recursively = opts.recursively)
+
+    for remote_file, local_file in downloads:
+        print("Downloading", remote_file, "as", local_file)
+
+    return 0

--- a/nextstrain/cli/command/remote/ls.py
+++ b/nextstrain/cli/command/remote/ls.py
@@ -47,7 +47,6 @@ def run(opts):
 
     files = remote.ls(url)
 
-    # XXX TODO: sort objects by parts
     for file in files:
         print(file)
 

--- a/nextstrain/cli/command/remote/ls.py
+++ b/nextstrain/cli/command/remote/ls.py
@@ -1,0 +1,50 @@
+"""
+List pathogen JSON data files or Markdown narratives on a remote source.
+ 
+URLs support optional path prefixes for restricting the files listed.
+
+    nextstrain remote list s3://my-bucket/some/prefix/
+
+will list files named "some/prefix/*".
+
+See `nextstrain remote --help` for more information on remote sources.
+"""
+
+from urllib.parse import urlparse
+from ...remote import s3
+from ...util import warn
+
+
+SUPPORTED_SCHEMES = {
+    "s3": s3,
+}
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser(
+        "list",
+        aliases = ["ls"],
+        help    = "List dataset and narrative files")
+
+    parser.add_argument(
+        "remote_path",
+        help    = "Remote path as a URL, with optional key/path prefix",
+        metavar = "<s3://bucket-name>")
+
+    return parser
+
+
+def run(opts):
+    url = urlparse(opts.remote_path)
+
+    if url.scheme not in SUPPORTED_SCHEMES:
+        warn("Error: Unsupported remote scheme %s://" % url.scheme)
+        warn("")
+        warn("Supported schemes are: %s" % ", ".join(SUPPORTED_SCHEMES))
+        return 1
+
+    remote = SUPPORTED_SCHEMES[url.scheme]
+
+    # XXX FIXME: return list of paths rather than only an int
+    # XXX TODO: sort objects by parts
+    return remote.ls(url)

--- a/nextstrain/cli/command/remote/ls.py
+++ b/nextstrain/cli/command/remote/ls.py
@@ -45,6 +45,10 @@ def run(opts):
 
     remote = SUPPORTED_SCHEMES[url.scheme]
 
-    # XXX FIXME: return list of paths rather than only an int
+    files = remote.ls(url)
+
     # XXX TODO: sort objects by parts
-    return remote.ls(url)
+    for file in files:
+        print(file)
+
+    return 0

--- a/nextstrain/cli/command/remote/upload.py
+++ b/nextstrain/cli/command/remote/upload.py
@@ -1,0 +1,61 @@
+"""
+Uploads (deploys) a set of built pathogen JSON data files or Markdown
+narratives to a remote source.
+
+Source URLs support optional path prefixes if you want your local filenames to
+be prefixed on the remote.  For example:
+
+    nextstrain remote upload s3://my-bucket/some/prefix/ auspice/zika*.json
+
+will upload files named "some/prefix/zika*.json".
+
+See `nextstrain remote --help` for more information on remote sources.
+"""
+
+from pathlib import Path
+from urllib.parse import urlparse
+from ...remote import s3
+from ...util import warn
+
+
+SUPPORTED_SCHEMES = {
+    "s3": s3,
+}
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser("upload", help = "Upload dataset and narrative files")
+
+    register_arguments(parser)
+    
+    return parser
+
+
+def register_arguments(parser):
+    # Destination
+    parser.add_argument(
+        "destination",
+        help    = "Remote path as a URL, with optional key/path prefix",
+        metavar = "<s3://bucket-name>")
+
+    # Files to upload
+    parser.add_argument(
+        "files",
+        help    = "Files to upload, typically Auspice JSON data files",
+        metavar = "<file.json>",
+        nargs   = "+")
+
+
+def run(opts):
+    url = urlparse(opts.destination)
+
+    if url.scheme not in SUPPORTED_SCHEMES:
+        warn("Error: Unsupported destination scheme %s://" % url.scheme)
+        warn("")
+        warn("Supported schemes are: %s" % ", ".join(SUPPORTED_SCHEMES))
+        return 1
+
+    remote = SUPPORTED_SCHEMES[url.scheme]
+    files  = [Path(f) for f in opts.files]
+
+    return remote.upload(url, files)

--- a/nextstrain/cli/command/remote/upload.py
+++ b/nextstrain/cli/command/remote/upload.py
@@ -58,4 +58,9 @@ def run(opts):
     remote = SUPPORTED_SCHEMES[url.scheme]
     files  = [Path(f) for f in opts.files]
 
-    return remote.upload(url, files)
+    uploads = remote.upload(url, files)
+
+    for local_file, remote_file in uploads:
+        print("Uploading", local_file, "as", remote_file)
+
+    return 0

--- a/nextstrain/cli/errors.py
+++ b/nextstrain/cli/errors.py
@@ -1,0 +1,10 @@
+"""
+Exception classes for internal use.
+"""
+
+class NextstrainCliError(Exception):
+    """Exception base class for all custom :mod:`nextstrain.cli` exceptions."""
+    pass
+
+class UserError(NextstrainCliError):
+    pass

--- a/nextstrain/cli/errors.py
+++ b/nextstrain/cli/errors.py
@@ -7,4 +7,5 @@ class NextstrainCliError(Exception):
     pass
 
 class UserError(NextstrainCliError):
-    pass
+    def __init__(self, message, *args, **kwargs):
+        super().__init__("Error: " + message, *args, **kwargs)

--- a/nextstrain/cli/gzip.py
+++ b/nextstrain/cli/gzip.py
@@ -1,0 +1,57 @@
+"""
+Gzip stream utilities.
+"""
+import zlib
+from io import BufferedIOBase
+from typing import BinaryIO
+
+
+class GzipCompressingReader(BufferedIOBase):
+    """
+    Compress a data stream as it is being read.
+
+    The constructor takes an existing, readable byte *stream*.  Calls to this
+    class's :meth:`.read` method will read data from the source *stream* and
+    return a compressed copy.
+    """
+    def __init__(self, stream: BinaryIO):
+        if not stream.readable():
+            raise ValueError('"stream" argument must be readable.')
+
+        self.stream = stream
+        self.__gzip = zlib.compressobj(
+            level = zlib.Z_BEST_COMPRESSION,
+            wbits = 16 + zlib.MAX_WBITS,    # Offset of 16 is gzip encapsulation
+            memLevel = 9,                   # Memory is ~cheap; use it for better compression
+        )
+
+    def readable(self):
+        return True
+
+    def read(self, size = None):
+        return self._compress(self.stream.read(size))
+
+    def read1(self, size = None):
+        return self._compress(self.stream.read1(size)) # type: ignore
+
+    def _compress(self, data: bytes):
+        if self.__gzip:
+            if data:
+                return self.__gzip.compress(data)
+            else:
+                # EOF on underlying stream, flush any remaining compressed
+                # data.  On the next call, we'll return EOF too.
+                try:
+                    return self.__gzip.flush(zlib.Z_FINISH)
+                finally:
+                    self.__gzip = None # type: ignore
+        else:
+            # Already hit EOF on the underlying stream and flushed.
+            return b''
+
+    def close(self):
+        if self.stream:
+            try:
+                self.stream.close()
+            finally:
+                self.stream = None

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -1,7 +1,7 @@
 """
-Deploy to S3 with automatic CloudFront invalidation.
+S3 remote with automatic CloudFront invalidation.
 
-Backend module for the deploy command.
+Backend module for the deploy family of commands.
 """
 
 import boto3
@@ -27,7 +27,7 @@ mimetypes.add_type("application/json", ".json")
 mimetypes.add_type("text/markdown", ".md")
 
 
-def run(url: urllib.parse.ParseResult, local_files: List[Path]) -> int:
+def deploy(url: urllib.parse.ParseResult, local_files: List[Path]) -> int:
     # Require a bucket name
     if not url.netloc:
         warn("No bucket name specified in url (%s)" % url.geturl())

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -150,7 +150,7 @@ def split_url(url: urllib.parse.ParseResult) -> Tuple[S3Bucket, str]:
         bucket = boto3.resource("s3").Bucket(url.netloc)
 
     except (NoCredentialsError, PartialCredentialsError) as error:
-        raise UserError("Error authenticating with S3: %s" % error) from error
+        raise UserError("Unable to authenticate with S3: %s" % error) from error
 
     # Find the bucket and ensure we have access and that it already exists so
     # we don't automagically create new buckets.

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -105,6 +105,12 @@ def delete(url: urllib.parse.ParseResult, recursively: bool = False) -> Tuple[It
     """
     bucket, path = split_url(url)
 
+    # Prevent unintentionally deleting everything recursively.  It also makes
+    # sense for non-recursive deletion, since we don't support deleting the
+    # bucket itself.
+    if not path:
+        raise UserError("No path specified for deletion.")
+
     # Delete either all objects sharing a prefix or the sole object (if any)
     # with the given key.  Both methods return the same results data structure.
     objects = bucket.objects.filter(Prefix = path)

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -82,6 +82,22 @@ def download(url: urllib.parse.ParseResult, local_path: Path, recursively: bool 
     return 0 if downloaded == len(files) else 1
 
 
+def ls(url: urllib.parse.ParseResult) -> int:
+    """
+    List the files deployed at the given remote *url*.
+    """
+    try:
+        bucket, prefix = split_url(url)
+    except UserError as error:
+        warn(error)
+        return 1
+
+    for object in bucket.objects.filter(Prefix = prefix):
+        print(object.key)
+
+    return 0
+
+
 def split_url(url: urllib.parse.ParseResult) -> Tuple:
     """
     Splits the given s3:// *url* into a Bucket object and normalized path

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -37,16 +37,17 @@ def deploy(url: urllib.parse.ParseResult, local_files: List[Path]) -> int:
     # prefix for uploaded files.  Internal and trailing slashes are untouched.
     prefix = url.path.lstrip("/")
 
-    bucket = boto3.resource("s3").Bucket(url.netloc)
+    try:
+        bucket = boto3.resource("s3").Bucket(url.netloc)
+
+    except (NoCredentialsError, PartialCredentialsError) as error:
+        warn("Error authenticating with S3: %s" % error)
+        return 1
 
     # Find the bucket and ensure we have access and that it already exists so
     # we don't automagically create new buckets.
     try:
         boto3.client("s3").head_bucket(Bucket = bucket.name)
-
-    except (NoCredentialsError, PartialCredentialsError) as error:
-        warn("Error:", error)
-        return 1
 
     except ClientError as error:
         warn('No bucket exists with the name "%s".' % bucket.name)

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -30,11 +30,7 @@ mimetypes.add_type("text/markdown", ".md")
 
 
 def upload(url: urllib.parse.ParseResult, local_files: List[Path]) -> int:
-    try:
-        bucket, prefix = split_url(url)
-    except UserError as error:
-        warn(error)
-        return 1
+    bucket, prefix = split_url(url)
 
     # Upload files
     remote_files = upload_(local_files, bucket, prefix)
@@ -50,11 +46,7 @@ def download(url: urllib.parse.ParseResult, local_path: Path, recursively: bool 
     Download the files deployed at the given remote *url*, optionally
     *recursively*, saving them into the *local_dir*.
     """
-    try:
-        bucket, path = split_url(url)
-    except UserError as error:
-        warn(error)
-        return 1
+    bucket, path = split_url(url)
 
     # Download either all objects sharing a prefix or the sole object (if any)
     # with the given key.
@@ -88,11 +80,7 @@ def ls(url: urllib.parse.ParseResult) -> int:
     """
     List the files deployed at the given remote *url*.
     """
-    try:
-        bucket, prefix = split_url(url)
-    except UserError as error:
-        warn(error)
-        return 1
+    bucket, prefix = split_url(url)
 
     for object in bucket.objects.filter(Prefix = prefix):
         print(object.key)
@@ -104,11 +92,7 @@ def delete(url: urllib.parse.ParseResult, recursively: bool = False) -> int:
     """
     Delete the files deployed at the given remote *url*, optionally *recursively*.
     """
-    try:
-        bucket, path = split_url(url)
-    except UserError as error:
-        warn(error)
-        return 1
+    bucket, path = split_url(url)
 
     # Delete either all objects sharing a prefix or the sole object (if any)
     # with the given key.  Both methods return the same results data structure.

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -20,6 +20,7 @@ from .. import aws
 from ..gzip import GzipCompressingReader, ContentDecodingWriter
 from ..util import warn, remove_prefix
 from ..errors import UserError
+from ..types import S3Bucket
 
 
 # Add these statically so that they're always available, even if there's no
@@ -149,7 +150,7 @@ def delete(url: urllib.parse.ParseResult, recursively: bool = False) -> int:
     return 0 if deleted and not errors else 1
 
 
-def split_url(url: urllib.parse.ParseResult) -> Tuple:
+def split_url(url: urllib.parse.ParseResult) -> Tuple[S3Bucket, str]:
     """
     Splits the given s3:// *url* into a Bucket object and normalized path
     with some sanity checking.

--- a/nextstrain/cli/runner/aws_batch/s3.py
+++ b/nextstrain/cli/runner/aws_batch/s3.py
@@ -10,18 +10,13 @@ from os import utime
 from pathlib import Path
 from tempfile import TemporaryFile
 from time import struct_time
-from typing import Any, Callable, Generator, Iterable, Optional
+from typing import Callable, Generator, Iterable, Optional
 from urllib.parse import urlparse
 from zipfile import ZipFile, ZipInfo
+from ...types import S3Bucket, S3Object
 
 
 PathMatcher = Callable[[Path], bool]
-
-# Cleaner-reading type annotations for boto3 S3 objects, which maybe can be
-# improved later.  The actual types are generated at runtime in
-# boto3.resources.factory, which means we can't use them here easily.  :(
-S3Bucket = Any
-S3Object = Any
 
 
 def object_url(object: S3Object) -> str:

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -4,9 +4,15 @@ Type aliases for internal use.
 
 import argparse
 import builtins
-from typing import List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 Options = argparse.Namespace
 
 RunnerTestResult  = Tuple[str, Union[bool, None, 'builtins.ellipsis']]
 RunnerTestResults = List[RunnerTestResult]
+
+# Cleaner-reading type annotations for boto3 S3 objects, which maybe can be
+# improved later.  The actual types are generated at runtime in
+# boto3.resources.factory, which means we can't use them here easily.  :(
+S3Bucket = Any
+S3Object = Any


### PR DESCRIPTION
Adds the following commands:

    nextstrain remote upload
    nextstrain remote download
    nextstrain remote delete (rm)
    nextstrain remote list (ls)

Resolves #36. Commentary in the commit messages.

---

I know we talk about names a _lot_, but, well, names are important and tend to stick around once you use them.  Currently this PR uses _remote_. _Remote_ is our "can't think of anything else" default from discussion in #36.  It's fine, but coming from git it probably isn't intrinsically descriptive to our users.  It's a container that describes the location the contained commands act on in relative terms (in opposition to _local_).

_Files_ is another name I've been thinking of that's probably way more immediately recognizable to most people:  

    nextstrain files upload
    nextstrain files download
    nextstrain files delete (rm)
    nextstrain files list (ls)

It's a container that describes what is acted on by the contained commands.  When we talk about "JSONs" informally, we're eliding the more specific phrase "Auspice JSON files" or "Augur JSON files", both of which can reasonably and collectively called "Nextstrain JSON files", or just "Nextstrain files".  A slight downside I see here is the focus on individual files, which may get in the way semantically of moving to actions focused on [_datasets_](https://github.com/nextstrain/nextstrain.org/blob/seattleflu-group/docs/glossary.md#dataset), where each dataset is actually multiple files.  But we can have both file-based and dataset-based commands; they're not exclusive.
