### PR TITLE
Travis CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,4 +69,5 @@ script:
   - nextstrain version
   - nextstrain check-setup
   - nextstrain update
-  - nextstrain build zika-tutorial
+  - nextstrain build --docker zika-tutorial
+  - nextstrain build --native zika-tutorial -F

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,21 +5,40 @@ services:
 
 language: python
 
+addons:
+  apt:
+    update: true
+
 matrix:
   include:
+    - dist: trusty
+      python: 3.6.1
+
     - dist: xenial
       python: 3.5
 
     - dist: xenial
       python: 3.6
 
-    - dist: trusty
-      python: 3.6.1
-
     - dist: xenial
       python: 3.7
 
     - dist: xenial
+      python: 3.8
+
+    - dist: xenial
+      python: 3.8-dev
+
+    - dist: bionic
+      python: 3.6
+
+    - dist: bionic
+      python: 3.7
+
+    - dist: bionic
+      python: 3.8
+
+    - dist: bionic
       python: 3.8-dev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,23 @@ services:
   - docker
 
 language: python
+cache: pip
+
+node_js: "12"
 
 addons:
   apt:
     update: true
+    packages:
+      - mafft
+      - iqtree
+      - raxml
+      - fasttree
+      - vcftools
+      - snakemake
 
 matrix:
   include:
-    - dist: trusty
-      python: 3.6.1
-
     - dist: xenial
       python: 3.5
 
@@ -43,7 +50,8 @@ matrix:
 
 install:
   - pip3 install .
-  - pip3 install flake8 mypy
+  - pip3 install flake8 mypy nextstrain-augur
+  - npm install --global auspice
 
 before_script:
   - git clone https://github.com/nextstrain/zika-tutorial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,39 +21,39 @@ matrix:
   include:
     - dist: xenial
       python: 3.5
-      name: "Ubuntu Xenial, Python 3.5"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.5"
 
     - dist: xenial
       python: 3.6
-      name: "Ubuntu Xenial, Python 3.6"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.6"
 
     - dist: xenial
       python: 3.7
-      name: "Ubuntu Xenial, Python 3.7"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.7"
 
     - dist: xenial
       python: 3.8
-      name: "Ubuntu Xenial, Python 3.8"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.8"
 
     - dist: xenial
       python: 3.8-dev
-      name: "Ubuntu Xenial, Python 3.8-dev"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.8-dev"
 
     - dist: bionic
       python: 3.6
-      name: "Ubuntu Bionic, Python 3.6"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.6"
 
     - dist: bionic
       python: 3.7
-      name: "Ubuntu Bionic, Python 3.7"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.7"
 
     - dist: bionic
       python: 3.8
-      name: "Ubuntu Bionic, Python 3.8"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8"
 
     - dist: bionic
       python: 3.8-dev
-      name: "Ubuntu Bionic, Python 3.8-dev"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8-dev"
 
 install:
   - pip3 install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,30 +23,39 @@ matrix:
   include:
     - dist: xenial
       python: 3.5
+      name: "Ubuntu Xenial, Python 3.5"
 
     - dist: xenial
       python: 3.6
+      name: "Ubuntu Xenial, Python 3.6"
 
     - dist: xenial
       python: 3.7
+      name: "Ubuntu Xenial, Python 3.7"
 
     - dist: xenial
       python: 3.8
+      name: "Ubuntu Xenial, Python 3.8"
 
     - dist: xenial
       python: 3.8-dev
+      name: "Ubuntu Xenial, Python 3.8-dev"
 
     - dist: bionic
       python: 3.6
+      name: "Ubuntu Bionic, Python 3.6"
 
     - dist: bionic
       python: 3.7
+      name: "Ubuntu Bionic, Python 3.7"
 
     - dist: bionic
       python: 3.8
+      name: "Ubuntu Bionic, Python 3.8"
 
     - dist: bionic
       python: 3.8-dev
+      name: "Ubuntu Bionic, Python 3.8-dev"
 
 install:
   - pip3 install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,58 +16,133 @@ addons:
       - fasttree
       - vcftools
       - snakemake
+      - git
 
-matrix:
+jobs:
   include:
-    - dist: xenial
+    - stage: build
+      dist: xenial
+      python: 2.7
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 2.7, Conda"
+      script: &conda_build
+        - export PATH=$HOME/.local/bin:$PATH
+        # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
+        - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+            wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+          else
+            wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+          fi
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - source "$HOME/miniconda/etc/profile.d/conda.sh"
+        - hash -r
+        - conda config --set always_yes yes --set changeps1 no
+        - conda update -q conda
+        # Useful for debugging any issues with conda
+        - conda info -a
+
+        - cd $HOME
+        # https://github.com/nextstrain/conda
+        - travis_retry curl http://data.nextstrain.org/nextstrain.yml -o nextstrain.yml
+        - conda env create -f nextstrain.yml
+        - travis_retry conda activate nextstrain
+
+        - cd $TRAVIS_BUILD_DIR
+        - travis_retry git clone https://github.com/nextstrain/zika-tutorial
+        - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+            pip install . ; pip install flake8 mypy nextstrain-augur;
+          else
+            pip3 install . ; pip3 install flake8 mypy nextstrain-augur;
+          fi
+        - npm install --global auspice
+
+        - flake8
+        - mypy nextstrain
+        - nextstrain version
+        - nextstrain check-setup
+        - nextstrain update
+        - nextstrain build --docker zika-tutorial
+        - nextstrain build --native zika-tutorial -F
+        
+    - stage: build
+      dist: xenial
       python: 3.5
-      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.5"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.5, Conda"
+      script: *conda_build
 
-    - dist: xenial
+    - stage: build
+      dist: xenial
       python: 3.6
-      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.6"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.6, Conda"
+      script: *conda_build
 
-    - dist: xenial
+    - stage: build
+      dist: xenial
       python: 3.7
-      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.7"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.7, Conda"
+      script: *conda_build
 
-    - dist: xenial
+    - stage: build
+      dist: xenial
       python: 3.8
-      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.8"
+      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.8, Conda"
+      script: *conda_build
 
-    - dist: xenial
-      python: 3.8-dev
-      name: "Ubuntu 16.04 LTS (Xenial Xerus), Python 3.8-dev"
-
-    - dist: bionic
+    - stage: build
+      dist: bionic
       python: 3.6
-      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.6"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.6, Conda"
+      script: *conda_build
 
-    - dist: bionic
+    - stage: build
+      dist: bionic
       python: 3.7
-      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.7"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.7, Conda"
+      script: *conda_build
 
-    - dist: bionic
+    - stage: build
+      dist: bionic
       python: 3.8
-      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8, Conda"
+      script: *conda_build
 
-    - dist: bionic
+    - stage: build
+      dist: bionic
       python: 3.8-dev
-      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8-dev"
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8-dev, Conda"
+      script: *conda_build
 
-install:
-  - pip3 install .
-  - pip3 install flake8 mypy nextstrain-augur
-  - npm install --global auspice
+    - stage: build
+      dist: bionic
+      python: 3.6
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.6, no Conda"
+      script: &non_conda_build
+        - git clone https://github.com/nextstrain/zika-tutorial
+        - pip3 install .
+        - pip3 install flake8 mypy nextstrain-augur
+        - npm install --global auspice
 
-before_script:
-  - git clone https://github.com/nextstrain/zika-tutorial
+        - flake8
+        - mypy nextstrain
+        - nextstrain version
+        - nextstrain check-setup
+        - nextstrain update
+        - nextstrain build --docker zika-tutorial
+        - nextstrain build --native zika-tutorial -F
 
-script:
-  - flake8
-  - mypy nextstrain
-  - nextstrain version
-  - nextstrain check-setup
-  - nextstrain update
-  - nextstrain build --docker zika-tutorial
-  - nextstrain build --native zika-tutorial -F
+    - stage: build
+      dist: bionic
+      python: 3.7
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.7, no Conda"
+      script: *non_conda_build
+
+    - stage: build
+      dist: bionic
+      python: 3.8
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8, no Conda"
+      script: *non_conda_build
+
+    - stage: build
+      dist: bionic
+      python: 3.8-dev
+      name: "Ubuntu 18.04 LTS (Bionic Beaver), Python 3.8-dev, no Conda"
+      script: *non_conda_build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nextstrain-cli
 
+[![Build Status](https://travis-ci.com/nextstrain/cli.svg?branch=master)](https://travis-ci.com/nextstrain/cli)
+
 This is the Nextstrain command-line tool.  It aims to provide access to
 Nextstrain components in a local environment with a minimum of fuss.
 


### PR DESCRIPTION
### Description of proposed changes    

This PR adds CI coverage for Ubuntu Bionic.  Also, "native is supported" is new:
```
# docker is supported
✔ yes: docker is installed
✔ yes: docker run works
? unknown: containers have access to >2 GiB of memory
✔ yes: image is new enough for this CLI version
# native is supported
✔ yes: snakemake is installed
✔ yes: augur is installed
✔ yes: auspice is installed
```
https://travis-ci.com/github/peterbecich/cli/jobs/307558291#L808-L817

The Ubuntu Trusty job has been removed because the Trusty distro lacks the apt packages `iqtree` and `snakemake`: https://travis-ci.com/github/peterbecich/cli/jobs/307556483#L712
If the Ubuntu Trusty job is important, I'd be happy to find a way to add it back and test `cli` in that job without the native support.

### Testing
The Ubuntu Xenial builds succeed for Python 3.5, 3.6, 3.7, 3.8 and 3.8-dev.  The Ubuntu Bionic builds succeed for Python 3.6, 3.7, 3.8 and 3.8-dev.
https://travis-ci.com/github/peterbecich/cli/builds/156295658
