### PR TITLE
Remove --tty flag from Docker invocation

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -79,7 +79,6 @@ def run(opts, argv, working_volume = None, extra_env = {}) -> int:
     return exec_or_return([
         "docker", "run",
         "--rm",             # Remove the ephemeral container after exiting
-        "--tty",            # Colors, etc.
         "--interactive",    # Pass through control signals (^C, etc.)
 
         # On Unix (POSIX) systems, run the process in the container with the same


### PR DESCRIPTION
fixes the issue on linux, should work on mac but needs be tested (I don't have one).  note that this will remove the colors in the term window - is it worth it? :)

fixes #49 