### PR TITLE
Add retries for the S3 resource

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,9 @@ python_version = 3.5
 [mypy-boto3]
 ignore_missing_imports = True
 
+[mypy-botocore.config]
+ignore_missing_imports = True
+
 [mypy-botocore.exceptions]
 ignore_missing_imports = True
 

--- a/nextstrain/cli/runner/aws_batch/s3.py
+++ b/nextstrain/cli/runner/aws_batch/s3.py
@@ -4,6 +4,7 @@ S3 handling for AWS Batch jobs.
 
 import binascii
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from calendar import timegm
 from os import utime
@@ -187,14 +188,15 @@ def bucket(name: str) -> S3Bucket:
     """
     Load an **existing** bucket from S3.
     """
-    bucket = boto3.resource("s3").Bucket(name)
+    config = Config(retries = {'max_attempts': 3})
+    s3_resource = boto3.resource("s3", config = config)
 
     try:
-        boto3.client("s3").head_bucket(Bucket = bucket.name)
+        s3_resource.meta.client.head_bucket(Bucket = name)
     except ClientError:
-        raise ValueError('Bucket named "%s" does not exist' % bucket.name)
+        raise ValueError('Bucket named "%s" does not exist' % name)
 
-    return bucket
+    return s3_resource.Bucket(name)
 
 
 def bucket_exists(name: str) -> bool:


### PR DESCRIPTION
### Description of proposed changes    
This adds 3 retries.  I'm not sure if this is excessive, but I do see sporadic failures in uploading the zip.  The better solution is to do a multipart upload with retries (since it wouldn't need to start all over), but this should be a UX improvement.

### Related issue(s)  
Fixes https://github.com/nextstrain/cli/issues/75

### Testing
Ran the zika tutorial
