### PR TITLE
[AWS Batch] Support overriding the container image used

### DIFF
--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 from argparse import ArgumentParser
+from textwrap import dedent
 from typing import Any, Mapping, List
 from . import docker, native, aws_batch
 from .. import config
@@ -104,6 +105,13 @@ def register_arguments(parser: ArgumentParser, runners: List, exec: List) -> Non
         "development options",
         "These should generally be unnecessary unless you're developing Nextstrain.")
 
+    # Image to use; shared by Docker and AWS Batch runners
+    development.add_argument(
+        "--image",
+        help    = "Container image name to use for the Nextstrain computing environment",
+        metavar = "<image>",
+        default = docker.DEFAULT_IMAGE)
+
     # Program to execute
     development.add_argument(
         "--exec",
@@ -147,6 +155,11 @@ def run(opts: Options, working_volume: NamedVolume = None, extra_env: Mapping = 
             opts.extra_exec_args
         )
     ]
+
+    if opts.image != docker.DEFAULT_IMAGE and opts.__runner__ is native:
+        warn(dedent("""
+            Warning: The specified --image=%s option is not used by --native.
+            """ % opts.image))
 
     return opts.__runner__.run(opts, argv, working_volume = working_volume, extra_env = extra_env)
 

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -130,6 +130,7 @@ def run(opts, argv, working_volume = None, extra_env = {}) -> int:
         try:
             job = jobs.submit(
                 name       = run_id,
+                image      = opts.image,
                 queue      = opts.job_queue,
                 definition = opts.job_definition,
                 cpus       = opts.cpus,

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -8,10 +8,10 @@ import requests
 import shutil
 import subprocess
 from textwrap import dedent
-from typing import Iterable, List, Tuple
+from typing import Iterable, List
 from .. import runner, hostenv, config
 from ..types import RunnerTestResults
-from ..util import warn, colored, capture_output, exec_or_return, resolve_path
+from ..util import warn, colored, capture_output, exec_or_return, resolve_path, split_image_name
 from ..volume import store_volume
 from ..__version__ import __version__
 
@@ -246,18 +246,6 @@ def update() -> bool:
         warn()
 
     return True
-
-
-def split_image_name(name: str) -> Tuple[str, str]:
-    """
-    Split the image *name* into a (repository, tag) tuple.
-    """
-    if ":" in name:
-        repository, tag = name.split(":", maxsplit = 2)
-    else:
-        repository, tag = name, "latest"
-
-    return (repository, tag)
 
 
 def is_build_tag(tag: str) -> bool:

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -36,12 +36,6 @@ def register_arguments(parser) -> None:
     development = parser.add_argument_group(
         "development options for --docker")
 
-    development.add_argument(
-        "--image",
-        help    = "Container image in which to run the pathogen build",
-        metavar = "<name>",
-        default = DEFAULT_IMAGE)
-
     development.set_defaults(volumes = [])
 
     for name in COMPONENTS:

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -5,7 +5,7 @@ import site
 import subprocess
 import sys
 from types import ModuleType
-from typing import Mapping, List
+from typing import Mapping, List, Tuple
 from pathlib import Path
 from pkg_resources import parse_version
 from shutil import which
@@ -213,3 +213,15 @@ def resolve_path(path: Path) -> Path:
         return path.resolve(strict = True) # type: ignore
     else:
         return path.resolve()
+
+
+def split_image_name(name: str) -> Tuple[str, str]:
+    """
+    Split the image *name* into a (repository, tag) tuple.
+    """
+    if ":" in name:
+        repository, tag = name.split(":", maxsplit = 2)
+    else:
+        repository, tag = name, "latest"
+
+    return (repository, tag)

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -217,7 +217,13 @@ def resolve_path(path: Path) -> Path:
 
 def split_image_name(name: str) -> Tuple[str, str]:
     """
-    Split the image *name* into a (repository, tag) tuple.
+    Split the Docker image *name* into a (repository, tag) tuple.
+
+    >>> split_image_name("nextstrain/base:build-20200424T101900Z")
+    ('nextstrain/base', 'build-20200424T101900Z')
+
+    >>> split_image_name("nextstrain/base")
+    ('nextstrain/base', 'latest')
     """
     if ":" in name:
         repository, tag = name.split(":", maxsplit = 2)


### PR DESCRIPTION
Job definitions are dynamically created as needed based on the base
definition specified by `--aws-batch-job`.  This is necessary to allow
runtime-configurable images since, unlike CPUs, memory, env vars, etc, a
submitted job may not directly override the container image set in the
job definition.

Resolves #57.  Implementation originally started as PR #73.

Co-authored-by: Julien BORDELLIER