### PR TITLE
Require docutils <0.16 in dev deps to avoid a version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
 
     extras_require = {
         "dev": [
+            "docutils<0.16",
             "flake8",
             "mypy",
             "nextstrain-sphinx-theme",


### PR DESCRIPTION
At some point in the last few weeks, Python 3.6.1 tests on Travis CI
started reliably failing with the nested exceptions:

    pkg_resources.ContextualVersionConflict: (docutils 0.16
    (/home/travis/virtualenv/python3.6.1/lib/python3.6/site-packages),
    Requirement.parse('docutils<0.16,>=0.10'), {'botocore'})

    pkg_resources.DistributionNotFound: The 'docutils<0.16,>=0.10'
    distribution was not found and is required by botocore

It appears that during install Pip ignores botocore's
docutils<0.16,>=0.10 dep in favor of recommonmark's docutils>=0.15.2
dep, and thus installs docutils 0.16.  Then, during runtime when
parse_version() is imported from pkg_resources, pkg_resources'
initialization code notices the problem and throws an exception.

I could reproduce locally by installing Python 3.6.1 with pyenv,
creating a venv, pip installing the same way .travis.yml does, and then
running the installed "nextstrain" program.

I believe the failures started when I added recommonmark (and thus the
transitive docutils dep) to the dev deps recently.  I don't know why
pkg_resources in other Python versions don't throw the error, but I did
test that using the latest pip and setuptools on Python 3.6.1 still
elicits the error.

