### PR TITLE
Use a minimal set of deps for RTD

### DIFF
--- a/.readthedocs-requirements.txt
+++ b/.readthedocs-requirements.txt
@@ -1,64 +1,11 @@
 # Read The Docs doesn't (yet?) support Pipenv-based dependency installs, so
-# instead we use this requirements file generated with `pipenv run pip freeze`.
+# instead we use this minimal requirements file.  It should be kept in sync
+# with setup.py.  When the need for an unreleased version of sphinx-argparse goes
+# away (presumably on its next release), then this whole file can go away and
+# .readthedocs.yml can install .[dev] or a new .[docs] directly.
 
-# The CLI itself.
-.
-
-# Output of `pipenv run pip freeze`, with the git-based package spec for the
-# CLI removed in favor of the above local dir spec.
-alabaster==0.7.12
-attrs==19.3.0
-Babel==2.8.0
-boto3==1.14.7
-botocore==1.17.7
-certifi==2020.4.5.2
-chardet==3.0.4
-commonmark==0.9.1
-docutils==0.15.2
-filelock==3.0.12
-flake8==3.8.3
-idna==2.9
-imagesize==1.2.0
-importlib-metadata==1.6.1
-Jinja2==2.11.2
-jmespath==0.10.0
-Markdown==3.2.2
-MarkupSafe==1.1.1
-mccabe==0.6.1
-more-itertools==8.4.0
-mypy==0.781
-mypy-extensions==0.4.3
-netifaces==0.10.9
-nextstrain-sphinx-theme==2020.2
-packaging==20.4
-pluggy==0.13.1
-py==1.8.2
-pycodestyle==2.6.0
-pyflakes==2.2.0
-Pygments==2.6.1
-pyparsing==2.4.7
-pytest==5.4.3
-pytest-flake8==1.0.6
-pytest-mypy==0.6.2
-python-dateutil==2.8.1
-pytz==2020.1
-recommonmark==0.6.0
-requests==2.24.0
-s3transfer==0.3.3
-six==1.15.0
-snowballstemmer==2.0.0
-Sphinx==3.1.1
+nextstrain-sphinx-theme
+recommonmark
+Sphinx>=3
 sphinx-argparse @ https://github.com/alex-rudakov/sphinx-argparse/archive/b3b649743d4f8854349a2416ccdd770f41739c35.tar.gz
-sphinx-markdown-tables==0.0.15
-sphinx-rtd-theme==0.5.0
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==1.0.3
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.4
-typed-ast==1.4.1
-typing-extensions==3.7.4.2
-urllib3==1.25.9
-wcwidth==0.2.4
-zipp==3.1.0
+sphinx-markdown-tables

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ setup(
     ],
 
     extras_require = {
+        # Documentation-generation deps should also be updated in the
+        # .readthedocs-requirements.txt file used by the RTD build.
         "dev": [
             "docutils<0.16",
             "flake8",


### PR DESCRIPTION
This should speed up doc builds and let newer versions of
nextstrain-sphinx-theme be automatically used.