### PR TITLE
s3 download: Fix usability when URL is a directory

### DIFF
--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -67,6 +67,11 @@ def download(url: urllib.parse.ParseResult, local_path: Path, recursively: bool 
     if recursively:
         objects = [ item.Object() for item in bucket.objects.filter(Prefix = path) ]
     else:
+        if not path:
+            raise UserError(dedent("""\
+                download: -r not specified; omitting directory '%s://%s'
+                """ % (str(url.scheme), str(url.netloc))))
+
         object = bucket.Object(path)
         assert_exists(object)
 

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -69,8 +69,10 @@ def download(url: urllib.parse.ParseResult, local_path: Path, recursively: bool 
     else:
         if not path:
             raise UserError(dedent("""\
-                download: -r not specified; omitting directory '%s://%s'
-                """ % (str(url.scheme), str(url.netloc))))
+                No file path specified in URL (%s); nothing to download.
+
+                Did you mean to use --recursively?
+                """ % (str(url.geturl()))))
 
         object = bucket.Object(path)
         assert_exists(object)


### PR DESCRIPTION
When downloading from an S3 scheme with `nextstrain remote download`,
fail more gracefully when the given URL is a directory but the recursive
option (-r) is not provided.

Resolves #93.