### PR TITLE
Upload individual output files from AWS Batch job

### DIFF
--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -123,6 +123,10 @@ def run(opts, argv, working_volume = None, extra_env = {}, cpus: int = None, mem
 
         print("uploaded:", s3.object_url(remote_workdir))
 
+        remote_files = s3.upload_workdir_individually(local_workdir, bucket, run_id)
+
+        for remote_file in remote_files:
+            print("uploaded:", s3.object_url(remote_file))
 
         # Submit job.
         print_stage("Submitting job")

--- a/nextstrain/cli/runner/aws_batch/s3.py
+++ b/nextstrain/cli/runner/aws_batch/s3.py
@@ -96,7 +96,8 @@ def upload_workdir_individually(workdir: Path, bucket: S3Bucket, run_id: str) ->
     remote_files = []
     for path in walk(workdir, excluded):
         filename = os_path.basename(str(path))
-        remote_file = bucket.Object(f"{run_id}/{filename}.zip")
+        remote_filename = "{run_id}/{filename}.zip".format(run_id=run_id, filename=filename)
+        remote_file = bucket.Object(remote_filename)
         remote_files.append(remote_file)
         with TemporaryFile() as tmpfile:
             with ZipFile(tmpfile, "w") as zipfile:


### PR DESCRIPTION
### Description of proposed changes    

This adds uploading of the individual files in the AWS Batch job working directory.

This is handy for situations when only one file needs to be downloaded, without downloading of the whole archive, which can be several gigabytes in size. Proposed by @emmahodcroft 

Note that this does not remove the upload of the large zip. Mostly because I simply don't know how it is used and whether there are tools that rely on its presence.

Implementation is a heavy copy-pate of the existing `upload_workdir()` function:
https://github.com/nextstrain/cli/blob/5bb2ccd4ec58c222015acd82d7fdc7fd4feca3cc/nextstrain/cli/runner/aws_batch/s3.py#L63-L71
with the loop logic inverted: instead of adding each file to the zip, we create a new zip for each file:
https://github.com/nextstrain/cli/blob/5bb2ccd4ec58c222015acd82d7fdc7fd4feca3cc/nextstrain/cli/runner/aws_batch/s3.py#L97-L105

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
N/A

### Testing
I guess we need to try and trigger an AWS Batch-hosted build and see how it goes :)


### Thank you for contributing to Nextstrain!
My pleasure :)