### PR TITLE
[build] Selective downloads and streaming upload/download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ language: python
 matrix:
   include:
     - dist: xenial
-      python: 3.5
-
-    - dist: xenial
       python: 3.6
 
     - dist: trusty

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -101,6 +101,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.8.4"
         },
+        "fsspec": {
+            "hashes": [
+                "sha256:5629dc945800873cb2092df806c854e74c2799f4854247bce37ca7171000a7ec",
+                "sha256:890c6ce9325030f03bd2eae81389ddcbcee53bdd475334ca064595e1e45f92a6"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.8.5"
+        },
         "idna": {
             "hashes": [
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",

--- a/doc/development.md
+++ b/doc/development.md
@@ -11,8 +11,7 @@
 
 Development of `nextstrain-cli` happens at <https://github.com/nextstrain/cli>.
 
-We currently target compatibility with Python 3.5 and higher.  This may be
-increased to 3.6 in the future.
+We currently target compatibility with Python 3.6 and higher.
 
 Versions for this project follow the [Semantic Versioning rules][].
 
@@ -70,17 +69,8 @@ During development you can run static type checks using [mypy][]:
 
 There are also many [editor integrations for mypy][].
 
-Note that our goal of compatibility with Python 3.5 means that type comments
-are necessary to annotate variable declarations:
-
-    # Not available in Python 3.5:
-    foo: int = 3
-
-    # Instead, use trailing type hint comments:
-    foo = 3  # type: int
-
 The [`typing_extensions`][] module should be used for features added to the
-standard `typings` module after 3.5.  (Currently this isn't necessary since we
+standard `typings` module after 3.6.  (Currently this isn't necessary since we
 don't use those features.)
 
 We also use [Flake8][] for some static analysis checks focusing on runtime

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -9,13 +9,13 @@
 <!-- WARNING -->
 <!-- WARNING -->
 
-## Python 3.5 or newer
+## Python 3.6 or newer
 
-This program is written in Python 3 and requires at least Python 3.5.  There are
+This program is written in Python 3 and requires at least Python 3.6.  There are
 many ways to install Python 3 on Windows, macOS, or Linux, including the
 [official packages][], [Homebrew][] for macOS, and the [Anaconda
 Distribution][].  Details are beyond the scope of this guide, but make sure you
-install Python 3.5 or higher.  You may already have Python 3 installed,
+install Python 3.6 or higher.  You may already have Python 3 installed,
 especially if you're on Linux.  Check by running `python --version` or `python3
 --version`.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,9 @@ ignore_missing_imports = True
 [mypy-botocore.exceptions]
 ignore_missing_imports = True
 
+[mypy-fsspec]
+ignore_missing_imports = True
+
 [mypy-netifaces]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
-# We currently aim for compat with 3.5.
-python_version = 3.5
+# We currently aim for compat with 3.6.
+python_version = 3.6
 
 # In the future maybe we can contribute typing stubs for these modules (either
 # complete stubs in the python/typeshed repo or partial stubs just in

--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -117,3 +117,20 @@ class ShowBriefHelp(Action):
         lines = full_help.splitlines(keepends = True)
 
         return "".join(list(takewhile(before_extra_argument_groups, lines)))
+
+
+class AppendOverwriteDefault(Action):
+    """
+    Similar to the core argparse ``append`` action, but overwrites the argument
+    ``default``, if any, instead of appending to it.
+
+    Thus, the ``default`` value is not included when the option is given and
+    may be a non-list value if desired.
+    """
+    def __call__(self, parser, namespace, value, option_string = None):
+        current = getattr(namespace, self.dest, None)
+
+        if current is parser.get_default(self.dest):
+            current = []
+
+        setattr(namespace, self.dest, [*current, value])

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -26,7 +26,7 @@ changes in the future as desired or necessary.
 import re
 from textwrap import dedent
 from .. import runner
-from ..argparse import add_extended_help_flags
+from ..argparse import add_extended_help_flags, AppendOverwriteDefault
 from ..util import byte_quantity, warn
 from ..volume import store_volume
 
@@ -73,6 +73,23 @@ def register_parser(subparser):
                   "Informs the AWS Batch instance size selection.  ",
         metavar = "<quantity>",
         type    = byte_quantity)
+
+    parser.add_argument(
+        "--download",
+        metavar = "<pattern>",
+        help    = "Only download modified files matching <pattern> from the remote build. "
+                  "Basic shell-style globbing is supported. "
+                  "May be passed more than once. "
+                  "Currently only supported when also using --aws-batch.",
+        default = True,
+        action  = AppendOverwriteDefault)
+
+    parser.add_argument(
+        "--no-download",
+        help   = "Do not download any files from the remote build when it completes. "
+                 "Currently only supported when also using --aws-batch.",
+        dest   = "download",
+        action = "store_false")
 
     # Positional parameters
     parser.add_argument(

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -254,10 +254,17 @@ def run(opts, argv, working_volume = None, extra_env = {}, cpus: int = None, mem
 
 
     # Download results if we didn't stop the job early.
-    if not stop_sent and not job.stopped:
-        print_stage("Downloading files modified by job to %s" % local_workdir)
+    if opts.download and not stop_sent and not job.stopped:
+        patterns = opts.download if isinstance(opts.download, list) else None
 
-        s3.download_workdir(remote_workdir, local_workdir)
+        if patterns:
+            print_stage("Downloading select files modified by job to %s" % local_workdir)
+            for pattern in patterns:
+                print("  - %s" % pattern)
+        else:
+            print_stage("Downloading all files modified by job to %s" % local_workdir)
+
+        s3.download_workdir(remote_workdir, local_workdir, patterns)
 
 
     # Exit with the job's exit code, or assume success

--- a/nextstrain/cli/runner/aws_batch/s3.py
+++ b/nextstrain/cli/runner/aws_batch/s3.py
@@ -67,8 +67,8 @@ def upload_workdir(workdir: Path, bucket: S3Bucket, run_id: str) -> S3Object:
     with TemporaryFile() as tmpfile:
         with ZipFile(tmpfile, "w") as zipfile:
             for path in walk(workdir, excluded):
+                print("zipping:", path)
                 zipfile.write(str(path), str(path.relative_to(workdir)))
-                print("zipped:", path)
 
         # …and upload it to S3
         tmpfile.seek(0)
@@ -121,6 +121,8 @@ def download_workdir(remote_workdir: S3Object, workdir: Path) -> None:
                     # that empty directories present in the archive but not
                     # locally are never created.
                     if member.CRC != crc32(workdir / path):
+                        print("unzipping:", workdir / path)
+
                         zipfile.extract(member, str(workdir))
 
                         # Update atime and mtime from the zip member; it's a
@@ -128,8 +130,6 @@ def download_workdir(remote_workdir: S3Object, workdir: Path) -> None:
                         # even optionally.
                         mtime = zipinfo_mtime(member)
                         utime(str(workdir / path), (mtime, mtime))
-
-                        print("unzipped:", workdir / path)
 
 
 def walk(path: Path, excluded: PathMatcher = lambda x: False) -> Generator[Path, None, None]:

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -108,7 +108,7 @@ def capture_output(argv):
     lines.
 
     This wrapper around subprocess.run() exists because its own capture_output
-    parameter wasn't added until Python 3.7 and we aim for compat with 3.5.
+    parameter wasn't added until Python 3.7 and we aim for compat with 3.6.
     When we bump our minimum Python version, we can remove this wrapper.
     """
     result = subprocess.run(

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,8 @@ setup(
         # License
         "License :: OSI Approved :: MIT License",
 
-        # Python 3 only; subprocess.run is >=3.5
+        # Python 3 only
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
 
@@ -79,7 +78,7 @@ setup(
         ],
     },
 
-    python_requires = '>=3.5',
+    python_requires = '>=3.6',
 
     install_requires = [
         "boto3",

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
 
     install_requires = [
         "boto3",
+        "fsspec",
         "netifaces >=0.10.6",
         "requests",
 


### PR DESCRIPTION
### Description of proposed changes

#### ❶ Support for selective downloading of remote build results

Adds two new options to the `nextstrain build` command:

    --download <pattern>
    --no-download

The former may be given multiple times and specifies patterns to match against build dir files which were modified by the remote build.  The latter skips downloading results entirely, which is useful if all you care about are the logs (such as when re-attaching to a build or when a build uploads results itself elsewhere).  The default is still to download every modified file.

Currently limited to `--aws-batch` builds, as the only remote environment supported.

This functionality will particularly help the ncov build shepherds, who often have the need to download only a few files from a very large build.

Resolves #104.  See also #83.

#### ❷ Stream uploads/downloads without using a temporary file.

This halves the local storage needed since no temporary file is involved and may also speed up the transfer of large builds since unmodified files do not need to be downloaded, just their metadata.

The change also opens the door for selective downloading as well, by making use of S3's seekability via HTTP Range headers.  fsspec encapsulates all these details for us into quite a nice abstraction!  I expect to use it more in this project in the future; it's worked out well in ID3C.

See also #83, although this sticks with zip archives.

#### ❸ Print file upload/download messages before each operation…

…instead of after.  Now you can see what large files are taking a moment to upload, instead of not knowing until they're complete!

### Testing
I've manually tested all combinations of the new options and existing functionality.