### PR TITLE
Drop netifaces and add --host option for view

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -30,8 +30,5 @@ ignore_missing_imports = True
 [mypy-fsspec]
 ignore_missing_imports = True
 
-[mypy-netifaces]
-ignore_missing_imports = True
-
 [mypy-nextstrain]
 ignore_missing_imports = True

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -14,7 +14,6 @@ or
 """
 
 import re
-import netifaces as net
 from pathlib import Path
 from typing import Iterable
 from .. import runner
@@ -117,18 +116,26 @@ def run(opts):
         "--publish=%s:%d:%d" % (host, port, port),
     ]
 
-    # Find the best remote address if we're allowing remote access.  While we
-    # listen on all interfaces (0.0.0.0), only the local host can connect to
-    # that successfully.  Remote hosts need a real IP on the network, which we
-    # do our best to discover.  If something goes wrong, ignore it and leave
-    # the host IP as-is (0.0.0.0); it'll at least work for local access.
-    if opts.allow_remote_access:
-        try:
-            remote_address = best_remote_address()
-        except:
-            pass
-        else:
-            host = remote_address
+    # XXX TODO: Find the best remote address if we're allowing remote access.
+    # While we listen on all interfaces (0.0.0.0), only the local host can
+    # connect to that successfully.  Remote hosts need a real IP on the
+    # network, which we do our best to discover.  If something goes wrong,
+    # ignore it and leave the host IP as-is (0.0.0.0); it'll at least work for
+    # local access.
+    #
+    # We used to use (in versions <= 3.0.4) the netifaces package to determine
+    # this, but netifaces became unmaintained and thus stopped having wheels
+    # built for newer Python versions.  This caused installation issues on a
+    # myriad of platforms since without wheels a full C toolchain is needed to
+    # install it.  For more context, see discussion starting with this comment:
+    #
+    #   <https://github.com/nextstrain/cli/issues/31#issuecomment-966609539>
+    #
+    # This comment exists as a reminder that spitting out http://0.0.0.0:4000
+    # is not very helpful and we should do better in the future if we
+    # reasonably can (e.g. use mDNS/Zeroconf to make nextstrain.your-computer.local
+    # Just Work, or even check if netifaces gets revived).
+    #   -trs, 17 Dec 2021
 
     # Show a helpful message about where to connect
     print_url(host, port, datasets)
@@ -194,30 +201,3 @@ def print_url(host, port, datasets):
 
     print(horizontal_rule)
     print()
-
-
-def best_remote_address():
-    """
-    Returns the "best" non-localback IP address for the local host, if
-    possible.  The "best" IP address is that bound to either the default
-    gateway interface, if any, else the arbitrary first interface found.
-
-    IPv4 is preferred, but IPv6 will be used if no IPv4 interfaces/addresses
-    are available.
-    """
-    default_gateway   = net.gateways().get("default", {})
-    default_interface = default_gateway.get(net.AF_INET,  (None, None))[1] \
-                     or default_gateway.get(net.AF_INET6, (None, None))[1] \
-                     or net.interfaces()[0]
-
-    interface_addresses = net.ifaddresses(default_interface).get(net.AF_INET)  \
-                       or net.ifaddresses(default_interface).get(net.AF_INET6) \
-                       or []
-
-    addresses = [
-        address["addr"]
-            for address in interface_addresses
-             if address.get("addr")
-    ]
-
-    return addresses[0] if addresses else None

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
 
     install_requires = [
         "fasteners",
-        "netifaces >=0.10.6",
         "pyjwt[crypto] >=2.0.0",
         "requests",
         "typing_extensions >=3.6.4",


### PR DESCRIPTION
### Description of proposed changes    
See commit messages.

### Related issue(s)  
Fixes #137.
Related to #31. 

### Testing
I've manually tested the new `--host` functionality in all permutations of {IPv4, IPv6, hostnames, omitted} × the {native, docker} runners.

pytest passes locally.

### After merge

- [ ] Remove `python3-netifaces` and `build-essentials` packages from the `nextstrain/ncov-ingest` image ([ref](https://github.com/nextstrain/ncov-ingest/pull/257#pullrequestreview-835665401))
- [ ] Remove [toolchain installation from Windows installation instructions](https://github.com/nextstrain/docs.nextstrain.org/blob/2cef2d69af829a376c6b506acf2cee79f8fcd3da/src/install.rst?plain=1#L103-L112)