### PR TITLE
runner.aws_batch: Exit 1 if the job failed but there's no job exit code

### DIFF
--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -267,8 +267,13 @@ def run(opts, argv, working_volume = None, extra_env = {}, cpus: int = None, mem
         s3.download_workdir(remote_workdir, local_workdir, patterns)
 
 
-    # Exit with the job's exit code, or assume success
-    return job.exit_code or 0
+    # Exit with the job's exit code if available or 1 if another failure,
+    # otherwise success.
+    return (
+        job.exit_code if job.exit_code is not None else
+                    1 if job.is_failed             else
+                    0
+    )
 
 
 def detach(job: jobs.JobState, local_workdir: Path) -> int:

--- a/nextstrain/cli/runner/aws_batch/jobs.py
+++ b/nextstrain/cli/runner/aws_batch/jobs.py
@@ -87,6 +87,10 @@ class JobState:
         return self.status in self.TERMINAL_STATUS
 
     @property
+    def is_failed(self) -> bool:
+        return self.status == "FAILED"
+
+    @property
     def elapsed_time(self) -> float:
         # Timestamps from the job state are in milliseconds
         created = self.state.get("createdAt", float("NaN"))  / 1000


### PR DESCRIPTION
Failed jobs do not have an exit code in Batch if the job failed for
infrastructural or reasons internal to AWS rather than job-specific
reasons.  For example, a job that fails because its EC2 instance is
shutdown in the middle of it will not have an exit code.

While `nextstrain build` used to exit 0 with success due to the missing
exit code, even though it correctly reported the job's failure and
failure reason.  Now it will exit 1 for a generic failure.

### Testing
Tested by attaching to 3 different kinds of already done jobs we had lying around:

1. Failed job where the build workflow exited 1. `nextstrain build` exits 1, as usual.
2. Failed job where the EC2 instance it was running on was terminated unexpectedly. `nextstrain build` now exits 1 with this PR.
3. Successful job where the build workflow exited 0. `nextstrain build` exits 0, as usual.