### PR TITLE
docs: Set "version" in Sphinx configuration

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,8 +18,11 @@
 # -- Project information -----------------------------------------------------
 
 from datetime import date
+from nextstrain.cli import __version__ as cli_version
 
 project = 'Nextstrain CLI'
+version = cli_version
+release = version
 copyright = '2018–%d, Trevor Bedford and Richard Neher' % (date.today().year)
 author = 'Thomas Sibley and the rest of the Nextstrain team'
 


### PR DESCRIPTION
This means the docs will include the specific version for "stable" on
Read the Docs with version 2022.1 or newer of nextstrain-sphinx-theme.

Also sets "release" as the Sphinx documentation says¹:

    If you don’t need the separation provided between version and
    release, just set them both to the same value.

¹ https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-release

