### PR TITLE
[check-setup] Improve memory limit check

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -144,12 +144,17 @@ def test_setup() -> RunnerTestResults:
             """
 
             try:
-                total, cgroup = map(int, run_bash(report_memory))
-            except (ValueError, OSError, subprocess.CalledProcessError):
-                # If for some reason we can't get both values...
+                limits = run_bash(report_memory)
+            except (OSError, subprocess.CalledProcessError):
                 pass
             else:
-                limit = cgroup if cgroup < total else total
+                def int_or_none(x):
+                    try:
+                        return int(x)
+                    except ValueError:
+                        return None
+
+                limit = min(filter(None, map(int_or_none, limits)))
 
                 if limit <= desired:
                     msg += dedent("""

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -140,12 +140,12 @@ def test_setup() -> RunnerTestResults:
         if image_exists():
             report_memory = """
                 awk '/^MemTotal:/ { print $2 * 1024 }' /proc/meminfo
-                cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+                cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null
             """
 
             try:
                 total, cgroup = map(int, run_bash(report_memory))
-            except ValueError:
+            except (ValueError, OSError, subprocess.CalledProcessError):
                 # If for some reason we can't get both values...
                 pass
             else:

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -140,7 +140,7 @@ def test_setup() -> RunnerTestResults:
         if image_exists():
             report_memory = """
                 awk '/^MemTotal:/ { print $2 * 1024 }' /proc/meminfo
-                cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null
+                (cat /sys/fs/cgroup/memory.max || cat /sys/fs/cgroup/memory/memory.limit_in_bytes) 2>/dev/null
             """
 
             try:


### PR DESCRIPTION
### Description of proposed changes    

- Improves the error handling of the check
- Supports host systems with cgroups v2
- Uses host limit even if cgroups limit isn't available

See commit messages for details.

### Related issue(s)  
Fixes #135.

### Testing
I tested using the [local VM setup I described](https://github.com/nextstrain/cli/issues/135#issuecomment-1051386199) in #135 by first reproducing the issues with nextstrain-cli 3.0.6 from PyPI and then installing this branch to see the issues resolved:

```console
$ pip3 install --user 'nextstrain-cli @ https://github.com/nextstrain/cli/archive/trs/cgroups-v2.zip'
…
$ ~/.local/bin/nextstrain check-setup
```

I also tested each commit individually to make sure they each worked as intended.