### PR TITLE
Measurements sidecar

### DIFF
--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -169,7 +169,7 @@ def dataset_paths(data_dir: Path) -> Iterable[str]:
     #   -trs, 11 Jan 2022
 
     # v2: All *.json files which don't end with a known sidecar or v1 suffix.
-    sidecar_suffixes = {"meta", "tree", "root-sequence", "seq", "sequences", "tip-frequencies", "entropy"}
+    sidecar_suffixes = {"meta", "tree", "root-sequence", "seq", "sequences", "tip-frequencies", "measurements", "entropy"}
 
     def sidecar_file(path):
         return any(path.name.endswith("_%s.json" % suffix) for suffix in sidecar_suffixes)

--- a/nextstrain/cli/remote/nextstrain_dot_org.py
+++ b/nextstrain/cli/remote/nextstrain_dot_org.py
@@ -120,7 +120,7 @@ class Dataset(Resource):
     def __init__(self, api_item):
         super().__init__(api_item)
 
-        default_sidecars = ["root-sequence", "tip-frequencies"]
+        default_sidecars = ["root-sequence", "tip-frequencies", "measurements"]
 
         self.subresources = [
             SubResource("application/vnd.nextstrain.dataset.main+json", ".json", primary = True),
@@ -637,13 +637,13 @@ def organize_files(paths: Iterable[Path]) -> OrganizedFiles:
 
     Returns a :class:`OrganizedFiles` tuple.
     """
-    # v1 dataset suffixes + our two dataset sidecar suffixes.
+    # v1 dataset suffixes + our three dataset sidecar suffixes.
     #
     # There are other conventional suffixes for node data files (see our data
     # formats doc¹), but we're not trying to handle node data files here.
     #
     # ¹ https://docs.nextstrain.org/en/latest/reference/data-formats.html
-    dataset_suffixes = {"meta", "tree", "root-sequence", "tip-frequencies"}
+    dataset_suffixes = {"meta", "tree", "root-sequence", "tip-frequencies", "measurements"}
 
     datasets:   Dict[str, Dict[str, Path]] = defaultdict(dict)
     narratives: Dict[str, Dict[str, Path]] = defaultdict(dict)
@@ -688,6 +688,7 @@ def sidecar_suffix(media_type: str) -> str:
     suffixes = {
         "application/vnd.nextstrain.dataset.root-sequence+json": "root-sequence",
         "application/vnd.nextstrain.dataset.tip-frequencies+json": "tip-frequencies",
+        "application/vnd.nextstrain.dataset.measurements+json": "measurements",
     }
     return suffixes.get(media_type, "")
 
@@ -697,5 +698,6 @@ def dataset_media_type(suffix: str) -> Optional[str]:
         "": "application/vnd.nextstrain.dataset.main+json",
         "root-sequence": "application/vnd.nextstrain.dataset.root-sequence+json",
         "tip-frequencies": "application/vnd.nextstrain.dataset.tip-frequencies+json",
+        "measurements": "application/vnd.nextstrain.dataset.measurements+json",
     }
     return media_types.get(suffix)


### PR DESCRIPTION
Add "measurements" sidecar file and media type. 
I searched for "tip-frequencies" within the repo and added "measurements" to the appropriate places.

Dependent on the API update in https://github.com/nextstrain/nextstrain.org/pull/481