### PR TITLE
Handle memory limits reported from Docker as floats

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -165,7 +165,7 @@ def test_setup() -> RunnerTestResults:
             else:
                 def int_or_none(x):
                     try:
-                        return int(x)
+                        return int(float(x))
                     except ValueError:
                         return None
 

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -184,6 +184,7 @@ def test_setup() -> RunnerTestResults:
                             """ % (limit / GiB))
                         status = None
                     else:
+                        msg += " (limit is %.1f GiB)" % (limit / GiB)
                         status = True
 
         return [(msg, status)]

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -169,19 +169,22 @@ def test_setup() -> RunnerTestResults:
                     except ValueError:
                         return None
 
-                limit = min(filter(None, map(int_or_none, limits)))
+                limits = list(filter(None, map(int_or_none, limits)))
 
-                if limit <= desired:
-                    msg += dedent("""
+                if limits:
+                    limit = min(limits)
 
-                        Containers appear to be limited to %0.1f GiB of memory. This
-                        may not be enough for some Nextstrain builds.  On Windows or
-                        a Mac, you can increase the memory available to containers
-                        in the Docker preferences.\
-                        """ % (limit / GiB))
-                    status = None
-                else:
-                    status = True
+                    if limit <= desired:
+                        msg += dedent("""
+
+                            Containers appear to be limited to %0.1f GiB of memory. This
+                            may not be enough for some Nextstrain builds.  On Windows or
+                            a Mac, you can increase the memory available to containers
+                            in the Docker preferences.\
+                            """ % (limit / GiB))
+                        status = None
+                    else:
+                        status = True
 
         return [(msg, status)]
 

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -153,24 +153,22 @@ def test_setup() -> RunnerTestResults:
         status: RunnerTestResultStatus = ...
 
         if image_exists():
+            def int_or_none(x):
+                try:
+                    return int(float(x))
+                except ValueError:
+                    return None
+
             report_memory = """
                 awk '/^MemTotal:/ { print $2 * 1024 }' /proc/meminfo
                 (cat /sys/fs/cgroup/memory.max || cat /sys/fs/cgroup/memory/memory.limit_in_bytes) 2>/dev/null
             """
 
             try:
-                limits = run_bash(report_memory)
+                limits = list(filter(None, map(int_or_none, run_bash(report_memory))))
             except (OSError, subprocess.CalledProcessError):
                 pass
             else:
-                def int_or_none(x):
-                    try:
-                        return int(float(x))
-                    except ValueError:
-                        return None
-
-                limits = list(filter(None, map(int_or_none, limits)))
-
                 if limits:
                     limit = min(limits)
 


### PR DESCRIPTION
## Context

The fix in #153 produced a new error for me with Docker 4.5.0 on OS X 10.14.6:

```bash
$ python3 -m pip install --upgrade nextstrain-cli
$ nextstrain --version
nextstrain.cli 3.1.1
$ cat ~/.nextstrain/config
[docker]
image = nextstrain/base:build-20220215T000459Z

[core]
runner = native
$ nextstrain check-setup --set-default
nextstrain-cli is up to date!

Testing your setup…
Traceback (most recent call last):
  File "/Users/jlhudd/miniconda3/envs/nextstrain/bin/nextstrain", line 8, in <module>
    sys.exit(main())
  File "/Users/jlhudd/miniconda3/envs/nextstrain/lib/python3.8/site-packages/nextstrain/cli/__main__.py", line 10, in main
    return cli.run( argv[1:] )
  File "/Users/jlhudd/miniconda3/envs/nextstrain/lib/python3.8/site-packages/nextstrain/cli/__init__.py", line 33, in run
    return opts.__command__.run(opts)
  File "/Users/jlhudd/miniconda3/envs/nextstrain/lib/python3.8/site-packages/nextstrain/cli/command/check_setup.py", line 63, in run
    runner_tests = [
  File "/Users/jlhudd/miniconda3/envs/nextstrain/lib/python3.8/site-packages/nextstrain/cli/command/check_setup.py", line 64, in <listcomp>
    (runner, runner.test_setup())
  File "/Users/jlhudd/miniconda3/envs/nextstrain/lib/python3.8/site-packages/nextstrain/cli/runner/docker.py", line 226, in test_setup
    *test_memory_limit(),
  File "/Users/jlhudd/miniconda3/envs/nextstrain/lib/python3.8/site-packages/nextstrain/cli/runner/docker.py", line 172, in test_memory_limit
    limit = min(filter(None, map(int_or_none, limits)))
ValueError: min() arg is an empty sequence
```

Inspecting the values of `limits` in pdb, I find:

```python
ipdb> limits
['4.1257e+09', 'max']
ipdb> print(list(map(int_or_none, limits)))
[None, None]
```

Since the OS reports the memory limit with an exponential value, `int` cannot interpret the string and returns a `ValueError`. However, `float` can interpret this string, so `int(float("4.1257e+09"))` produces `4125700000`, as expected.

After changing `int_or_none` accordingly, I ran the `nextstrain` command again (this time from a local dev installation with my changes).

```
$ nextstrain check-setup --set-default
$ cat ~/.nextstrain/config
[docker]
image = nextstrain/base:build-20220215T000459Z

[core]
runner = docker
```

And the command ran as expected.

### Description of proposed changes

Fixes the issue described above on Mac OS X with Docker where `check-setup --set-default` fails when the memory limits reported from the Docker OS are in floating point values (e.g., "") that cannot be cast to integers by Python. This commit addresses the issue by first casting the string to float before casting to int.

### Related issue(s)

Related to #153

### Testing

 - [x] Tested locally to confirm the issue was fixed for me
 - [ ] Tested by CI