### PR TITLE
runner.docker: Distinguish between an explicit vs. implicit "latest" image tag when updating

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -17,6 +17,10 @@ from ..volume import store_volume
 from ..__version__ import __version__
 
 
+# The default intentionally omits an explicit "latest" tag so that on the first
+# `nextstrain update` it gets pinned in the config file to the most recent
+# "build-*" tag.  Users can set an explicit "latest" tag in config to always
+# use the most recent image and not pin to "build-*" tags.
 DEFAULT_IMAGE = os.environ.get("NEXTSTRAIN_DOCKER_IMAGE") \
              or config.get("docker", "image") \
              or "nextstrain/base"
@@ -296,10 +300,42 @@ def latest_build_image(image_name: str) -> str:
     is better than using the "latest" tag since the former is more descriptive
     and points to a static snapshot instead of a mutable snapshot.
 
-    If the given *image_name* is not tagged "build-*" or "latest" (implicitly
-    or explicitly), then the given *image_name* is returned as-is under the
-    presumption that it points to some other mutable snapshot that should be
-    pulled in-place to update.
+    If the given *image_name* has a tag but it isn't a "build-*" tag, then the
+    given *image_name* is returned as-is under the presumption that it points
+    to some other mutable snapshot that should be pulled in-place to update.
+    This means, for example, that users can opt into tracking the "latest" tag
+    by explicitly configuring it as the image to use (versus omitting the
+    "latest" tag).
+
+    Examples
+    --------
+
+    When a newer "build-*" tag exists, it's returned.
+
+    >>> old = "nextstrain/base:build-20220215T000459Z"
+    >>> new = latest_build_image(old)
+    >>> _, old_tag = split_image_name(old)
+    >>> _, new_tag = split_image_name(new)
+    >>> old_tag
+    'build-...'
+    >>> new_tag
+    'build-...'
+    >>> new_tag > old_tag
+    True
+
+    When a non-build tag is present, it's simply passed through.
+
+    >>> latest_build_image("nextstrain/base:latest")
+    'nextstrain/base:latest'
+
+    >>> latest_build_image("nextstrain/base:example")
+    'nextstrain/base:example'
+
+    When no tag is present (i.e. implicitly "latest"), a "build-*" tag is
+    returned.
+
+    >>> latest_build_image("nextstrain/base")
+    'nextstrain/base:build-...'
     """
     def GET(url, **kwargs):
         response = requests.get(url, **kwargs)
@@ -320,17 +356,15 @@ def latest_build_image(image_name: str) -> str:
         }
         return GET(url, headers = headers).json().get("tags", [])
 
-    repository, tag = split_image_name(image_name)
+    repository, tag = split_image_name(image_name, implicit_latest = False)
 
-    if tag == "latest" or is_build_tag(tag):
+    if not tag or is_build_tag(tag):
         build_tags = sorted(filter(is_build_tag, tags(repository)))
 
         if build_tags:
             return repository + ":" + build_tags[-1]
-        else:
-            return repository + ":latest"
-    else:
-        return image_name
+
+    return image_name
 
 
 def old_build_images(name: str) -> List[str]:

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -264,8 +264,8 @@ def update() -> bool:
     print()
 
     try:
-        images = dangling_images(current_image) \
-               + old_build_images(current_image)
+        images = dangling_images(latest_image) \
+               + old_build_images(latest_image)
 
         if images:
             subprocess.run(

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -5,7 +5,8 @@ import site
 import subprocess
 import sys
 from types import ModuleType
-from typing import Any, Callable, Mapping, List, Sequence, Tuple, Union
+from typing import Any, Callable, Mapping, List, Optional, Sequence, Tuple, Union, overload
+from typing_extensions import Literal
 from pathlib import Path
 from pkg_resources import parse_version
 from shutil import which
@@ -297,7 +298,15 @@ def byte_quantity(quantity: str) -> int:
     return int(value * unit_factor[units.lower()])
 
 
-def split_image_name(name: str) -> Tuple[str, str]:
+@overload
+def split_image_name(name: str, implicit_latest: Literal[True] = True) -> Tuple[str, str]:
+    ...
+
+@overload
+def split_image_name(name: str, implicit_latest: Literal[False]) -> Tuple[str, Optional[str]]:
+    ...
+
+def split_image_name(name: str, implicit_latest: bool = True) -> Tuple[str, Optional[str]]:
     """
     Split the Docker image *name* into a (repository, tag) tuple.
 
@@ -306,11 +315,17 @@ def split_image_name(name: str) -> Tuple[str, str]:
 
     >>> split_image_name("nextstrain/base")
     ('nextstrain/base', 'latest')
+
+    >>> split_image_name("nextstrain/base", implicit_latest = False)
+    ('nextstrain/base', None)
+
+    >>> split_image_name("nextstrain/base:latest", implicit_latest = False)
+    ('nextstrain/base', 'latest')
     """
     if ":" in name:
         repository, tag = name.split(":", maxsplit = 2)
     else:
-        repository, tag = name, "latest"
+        repository, tag = name, "latest" if implicit_latest else None
 
     return (repository, tag)
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         "fasteners",
         "pyjwt[crypto] >=2.0.0",
         "requests",
-        "typing_extensions >=3.6.4",
+        "typing_extensions >=3.7.4",
         "wcmatch >=6.0",
 
         # We use fsspec's S3 support, which has a runtime dep on s3fs.  s3fs


### PR DESCRIPTION
### Description of proposed changes
Behaviour with an implicit "latest" tag remains the same: it resolves to
the most recent "build-*" tag when `nextstrain update` is run which then
pins it in the config file.

An explicit "latest" tag used to do the same but now is preserved: it's
not updated to the most recent "build-*" tag during `nextstrain update`.
This allows folks to opt into tracking the leading edge of changes to
the image.

Resolves <https://github.com/nextstrain/cli/issues/96>.

### Testing
Tested locally and works for me. Also added additional doctests.