### PR TITLE
runner.docker: Set docker.image setting to the latest build-* tag by default

### DIFF
--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -94,18 +94,20 @@ def run(opts: Options) -> int:
 
     # Print overall status.
     supported_runners = [
-        runner_name(runner)
+        runner
             for runner, status_ok in runner_status.items()
              if status_ok
     ]
 
     if supported_runners:
-        print("All good!  Supported Nextstrain environments:", ", ".join(map(success, supported_runners)))
+        print("All good!  Supported Nextstrain environments:", ", ".join(success(runner_name(r)) for r in supported_runners))
 
         if opts.set_default:
+            default_runner = supported_runners[0]
             print()
-            print("Setting default environment to %s." % supported_runners[0])
-            config.set("core", "runner", supported_runners[0])
+            print("Setting default environment to %s." % runner_name(default_runner))
+            config.set("core", "runner", runner_name(default_runner))
+            default_runner.set_default_config()
     else:
         print(failure("No good.  No support for any Nextstrain environment."))
 

--- a/nextstrain/cli/config.py
+++ b/nextstrain/cli/config.py
@@ -108,6 +108,24 @@ def set(section: str, field: str, value: str, path: Path = CONFIG):
         save(config, path)
 
 
+def setdefault(section: str, field: str, value: str, path: Path = CONFIG):
+    """
+    Set *field* in *section* to *value* in the config file at the given *path*,
+    if *field* doesn't already exist.
+
+    If *section* does not exist, it is automatically created.
+    """
+    with write_lock():
+        config = load(path)
+
+        if section not in config:
+            config.add_section(section)
+
+        config[section].setdefault(field, value)
+
+        save(config, path)
+
+
 def remove(section: str, path: Path) -> bool:
     """
     Remove the *section* in the config file at the given *path*.

--- a/nextstrain/cli/config.py
+++ b/nextstrain/cli/config.py
@@ -103,7 +103,7 @@ def set(section: str, field: str, value: str, path: Path = CONFIG):
         if section not in config:
             config.add_section(section)
 
-        config.set(section, field, value)
+        config[section][field] = value
 
         save(config, path)
 

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -349,6 +349,13 @@ def test_setup() -> RunnerTestResults:
     ]
 
 
+def set_default_config() -> None:
+    """
+    No-op.
+    """
+    pass
+
+
 def update() -> bool:
     """
     No-op.  Updating the AWS Batch environment isn't meaningful.

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -230,6 +230,13 @@ def test_setup() -> RunnerTestResults:
     ]
 
 
+def set_default_config() -> None:
+    """
+    No-op.
+    """
+    pass
+
+
 def update() -> bool:
     """
     Pull down the latest Docker image build and prune old image versions.

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -232,9 +232,10 @@ def test_setup() -> RunnerTestResults:
 
 def set_default_config() -> None:
     """
-    No-op.
+    Sets ``docker.image``, if it isn't already set, to the latest ``build-*``
+    image.
     """
-    pass
+    config.setdefault("docker", "image", latest_build_image(DEFAULT_IMAGE))
 
 
 def update() -> bool:

--- a/nextstrain/cli/runner/native.py
+++ b/nextstrain/cli/runner/native.py
@@ -41,6 +41,13 @@ def test_setup() -> RunnerTestResults:
     ]
 
 
+def set_default_config() -> None:
+    """
+    No-op.
+    """
+    pass
+
+
 def update() -> bool:
     """
     No-op.  Updating the native environment isn't reasonably possible.

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -41,6 +41,9 @@ class RunnerModule(Protocol):
     def test_setup() -> Any: ...
 
     @staticmethod
+    def set_default_config() -> None: ...
+
+    @staticmethod
     def update() -> bool: ...
 
     @staticmethod


### PR DESCRIPTION
This is called when the runner is set as the default runner by
`nextstrain check-setup --set-default`.

Partially resolves <https://github.com/nextstrain/cli/issues/167>.

---

See other commit messages for more details.

### Testing
Tested new setting of defaults locally. `pytest` passes locally.