### PR TITLE
docs: Update cross-link to Nextstrain Groups explanatory documentation

### DIFF
--- a/nextstrain/cli/remote/nextstrain_dot_org.py
+++ b/nextstrain/cli/remote/nextstrain_dot_org.py
@@ -9,8 +9,8 @@ and :doc:`delete </commands/remote/delete>`
 Nextstrain :term:`datasets <docs:dataset>` and :term:`narratives
 <docs:narrative>` hosted on `nextstrain.org <https://nextstrain.org>`_.  This
 functionality is primarily intended for users to manage the contents of their
-:doc:`Nextstrain Groups <docs:guides/share/nextstrain-groups>`, but any public
-dataset or narrative may be downloaded.
+:doc:`Nextstrain Groups <docs:learn/groups/index>`, but any public dataset or
+narrative may be downloaded.
 
 
 Remote paths

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -9,7 +9,7 @@ Nextstrain :term:`datasets <docs:dataset>` and :term:`narratives
 This functionality is primarily intended for use by the Nextstrain team and
 operators of self-hosted :term:`docs:Auspice` instances.  It is also used to
 manage the contents of :doc:`Nextstrain Groups
-<docs:guides/share/nextstrain-groups>` that have not migrated to using the
+<docs:learn/groups/index>` that have not migrated to using the
 :doc:`/remotes/nextstrain.org`.
 
 


### PR DESCRIPTION
### Description of proposed changes
The previous page recently moved and Groups doc in general was
overhauled.  Redirects are in place, so existing CLI docs pointing at
the old link still work.  This fixes newly generated CLI docs and avoids
CI errors from Sphinx warnings.

### Related issue(s)
Related to https://github.com/nextstrain/docs.nextstrain.org/pull/104. Causing unrelated CI failures in #172.

### Testing
Ran docs locally with warnings fatalized and all was well. Will look at CI and then merge.