### PR TITLE
runner: Error instead of warn when --image is used with the "native" runner

### DIFF
--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -9,6 +9,7 @@ from . import (
     aws_batch as __aws_batch,
 )
 from .. import config
+from ..errors import UserError
 from ..types import Options, RunnerModule
 from ..util import runner_name, runner_help, warn
 from ..volume import NamedVolume
@@ -190,11 +191,12 @@ def run(opts: Options, working_volume: NamedVolume = None, extra_env: Mapping = 
         )
     ]
 
-    if (opts.image != docker.DEFAULT_IMAGE # type: ignore
+    if (opts.image is not docker.DEFAULT_IMAGE # type: ignore
     and opts.__runner__ is native):
-        warn(dedent("""
-            Warning: The specified --image=%s option is not used by --native.
-            """ % opts.image))
+        why_native = "the configured default" if default_runner is native else "selected by --native"
+        raise UserError(f"""
+            The --image option is incompatible with the "native" runner ({why_native}).
+            """)
 
     return opts.__runner__.run(opts, argv, working_volume = working_volume, extra_env = extra_env, cpus = cpus, memory = memory)
 


### PR DESCRIPTION
It seems better to abort early with a clear error than to continue with
a warning that's easy to miss.  Particularly so since continuing while
ignoring --image might mean distant errors quite a while later (at best)
or hard-to-detect erroneous results (at worst).

Narrows the conditional to no longer exclude invocations where --image
was given explicitly but with a value that matched the default.

### Testing
- [x] Ran permutations of with and without `--image` × different runners