### PR TITLE
runner.aws_batch: Use containerOverrides.resourceRequirements instead of .vcpu and .memory

### DIFF
--- a/nextstrain/cli/runner/aws_batch/jobs.py
+++ b/nextstrain/cli/runner/aws_batch/jobs.py
@@ -177,8 +177,10 @@ def submit(name: str,
                 *forwarded_environment(),
                 *[{"name": name, "value": value} for name, value in env.items()]
             ],
-            **({ "vcpus": cpus } if cpus else {}),
-            **({ "memory": memory } if memory else {}),
+            "resourceRequirements": [
+                *([{ "type": "VCPU", "value": str(cpus) }] if cpus else []),
+                *([{ "type": "MEMORY", "value": str(memory) }] if memory else []),
+            ],
             "command": [
                 "/sbin/entrypoint-aws-batch",
                 *exec


### PR DESCRIPTION
Job submissions with resourceRequirements correctly override the
defaults from job definitions that use the newer resourceRequirements
and those that use the older, deprecated vcpu and memory fields.  Job
submissions using the older fields only override job definitions that
also use the older fields; otherwise they're ignored with only an easy
to miss warning in the AWS console to alert you.

Notably, using the AWS console to modify an existing job definition
which uses vcpus and memory will switch the definition to
resourceRequirements automatically in the new revision.  This meant
revising your old job definition in the AWS console could break --cpus
and --memory for your `nextstrain build` invocations.  It also means
that --cpus and --memory would never have worked if your AWS job
definitions were originally created with resourceRequirements.

Resolves <https://github.com/nextstrain/cli/issues/144>.

### Testing
See #144 for how/what I tested.