### PR TITLE
Build standalone installation archives with PyOxidizer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,11 +111,23 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Set DIST, DIST_VERSION, and INSTALLATION_ARCHIVE_STEM
+        run: |
+          DIST=(dist/nextstrain_cli-*-py3-none-any.whl)
+          DIST_VERSION="$DIST"
+          DIST_VERSION="${DIST_VERSION#dist/nextstrain_cli-}"
+          DIST_VERSION="${DIST_VERSION%-py3-none-any.whl}"
+          INSTALLATION_ARCHIVE_STEM="nextstrain-cli-${DIST_VERSION}-standalone-${{ matrix.target }}"
+
+          for var in DIST DIST_VERSION INSTALLATION_ARCHIVE_STEM; do
+            echo "${var}=${!var}" | tee -a "$GITHUB_ENV"
+          done
+
       - run: |
           pyoxidizer build \
             --release \
             --target-triple ${{ matrix.target }} \
-            --var NEXTSTRAIN_CLI_DIST dist/nextstrain_cli-*-py3-none-any.whl
+            --var NEXTSTRAIN_CLI_DIST "$DIST"
 
       # Analyze the executable for potential portability issues.
       #
@@ -141,10 +153,10 @@ jobs:
       # zip on Windows because it's a native format which requires no extra
       # tooling.
       - if: runner.os != 'Windows'
-        run: tar czvpf ${{ matrix.target }}.tar.gz -C build/${{ matrix.target }}/release/installation/ .
+        run: tar czvpf "$INSTALLATION_ARCHIVE_STEM.tar.gz" -C build/${{ matrix.target }}/release/installation/ .
 
       - if: runner.os == 'Windows'
-        run: Compress-Archive -DestinationPath ${{ matrix.target }}.zip -Path build/${{ matrix.target }}/release/installation/*
+        run: Compress-Archive -DestinationPath "$Env:INSTALLATION_ARCHIVE_STEM.zip" -Path build/${{ matrix.target }}/release/installation/*
         shell: pwsh
 
       # Upload installation archive as a workflow artifact.
@@ -152,10 +164,10 @@ jobs:
       # At least one path needs to match, or this errors.
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.target }}
+          name: standalone-${{ matrix.target }}
           path: |
-            ${{ matrix.target }}.tar.gz
-            ${{ matrix.target }}.zip
+            ${{ env.INSTALLATION_ARCHIVE_STEM }}.tar.gz
+            ${{ env.INSTALLATION_ARCHIVE_STEM }}.zip
           if-no-files-found: error
 
       # Quick smoke test that the executable at least runs!  Useful before
@@ -249,13 +261,13 @@ jobs:
       # Download and extract the installation archive.
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.target }}
+          name: standalone-${{ matrix.target }}
 
       - if: runner.os != 'Windows'
-        run: tar xzvpf ${{ matrix.target }}.tar.gz
+        run: tar xzvpf nextstrain-cli-*-standalone-${{ matrix.target }}.tar.gz
 
       - if: runner.os == 'Windows'
-        run: Expand-Archive -Path ${{ matrix.target }}.zip -DestinationPath .
+        run: Expand-Archive -Path nextstrain-cli-*-standalone-${{ matrix.target }}.zip -DestinationPath .
         shell: pwsh
 
       - run: echo "$PWD" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,111 @@ jobs:
           name: dist
           path: dist/
 
+  build-standalone:
+    needs: build-dist
+    strategy:
+      fail-fast: false
+      matrix:
+        # Generally we want to build on the oldest supported OS to maximize the
+        # final binary's compatibility.  See pyoxidizer's docs for more
+        # considerations affecting the choice of build machine OS¹ and future
+        # plans for robust, turnkey build environments².
+        #
+        # ¹ https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_distributing_binary_portability.html
+        # ² https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_status.html#an-official-build-environment
+        #
+        # XXX TODO: GitHub doesn't yet host any runners on M1 (Apple Silicon,
+        # aarch64, arm64) hardware, and we don't have M1 hardware on which to
+        # self-host a runner.  Amazon's mac2.metal EC2 instances are M1, but
+        # they cost a minimum of ~$15/day.  It would be cheaper to buy an M1
+        # Mac Mini for ~$700 which would pay for itself in less than 2 months.
+        #   -trs, 31 May 2022
+        include:
+          - os: ubuntu-18.04
+            target: x86_64-unknown-linux-gnu
+            exe: nextstrain
+
+          - os: macos-10.15
+            target: x86_64-apple-darwin
+            exe: nextstrain
+
+          - os: windows-2019
+            target: x86_64-pc-windows-msvc
+            exe: nextstrain.exe
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # Install pyoxidizer.
+      #
+      # Even though it's a Rust project, the easiest cross-platform way to
+      # install it is via pip since they publish wheels with the binaries. :-)
+      # Note that this Python version doesn't impact the actual build.
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - run: pip install pyoxidizer
+
+      # Build the executable + necessary external files from the dists.
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+
+      - run: |
+          pyoxidizer build \
+            --release \
+            --target-triple ${{ matrix.target }} \
+            --var NEXTSTRAIN_CLI_DIST dist/nextstrain_cli-*-py3-none-any.whl
+
+      # Analyze the executable for potential portability issues.
+      #
+      # This is for informational purposes only in build logs, so we don't care
+      # if it fails.  Currently it only works on Linux, though it's supposed to
+      # eventually work on all platforms supported by pyoxidizer.
+      - if: runner.os == 'Linux'
+        run: pyoxidizer analyze build/${{ matrix.target }}/release/installation/${{ matrix.exe }}
+        continue-on-error: true
+
+      # XXX TODO: Review and report on licensing of all the stuff built into
+      # the binary, as bundling things statically can trigger different license
+      # terms than "normal" installs (e.g. via pip).  See also pyoxidizer's
+      # docs about this and the tooling it includes to support license review.¹
+      #   -trs, 1 June 2022
+      #
+      # ¹ https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_packaging_licensing.html#licensing-considerations
+
+      # Create installation archive.
+      #
+      # Use tar on Unix to preserve file modes (e.g. the executable bit), thus
+      # avoiding having to restore them manually after archive extraction.  Use
+      # zip on Windows because it's a native format which requires no extra
+      # tooling.
+      - if: runner.os != 'Windows'
+        run: tar czvpf ${{ matrix.target }}.tar.gz -C build/${{ matrix.target }}/release/installation/ .
+
+      - if: runner.os == 'Windows'
+        run: Compress-Archive -DestinationPath ${{ matrix.target }}.zip -Path build/${{ matrix.target }}/release/installation/*
+        shell: pwsh
+
+      # Upload installation archive as a workflow artifact.
+      #
+      # At least one path needs to match, or this errors.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            ${{ matrix.target }}.tar.gz
+            ${{ matrix.target }}.zip
+          if-no-files-found: error
+
+      # Quick smoke test that the executable at least runs!  Useful before
+      # launching the more extensive tests below.
+      - run: ./build/${{ matrix.target }}/release/installation/${{ matrix.exe }} --help
+
   test-dist:
     needs: build-dist
     name: test-dist (python=${{ matrix.python }} os=${{ matrix.os }})
@@ -95,6 +200,65 @@ jobs:
 
       - name: Install Nextstrain CLI
         run: python3 -m pip install --upgrade dist/nextstrain_cli-*-py3-none-any.whl
+
+      - uses: ./src/.github/actions/run-integration-tests
+
+  test-standalone:
+    needs: build-standalone
+    name: test-standalone (os=${{ matrix.os}}, target=${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test on all the platforms available via GitHub Actions.
+        #
+        # Ideally we'd test on machines with ~fresh OS installs.  The kitchen
+        # sink of development/build software pre-installed into GitHub Action's
+        # virtual-environments has a decent risk of making this CI blind to
+        # end-user runtime issues with our binaries (e.g. missing DLLs).  Such
+        # fresh CI machines are not readily available, however, since
+        # pre-installation is convenient for builds.
+        #
+        # XXX TODO: macOS aarch64 (M1, Apple Silicon, arm64); see above.
+        #
+        # XXX TODO: Include macos-12 once it includes a pre-installed Conda.
+        # <https://github.com/actions/virtual-environments/issues/5623>
+        include:
+          - { os: ubuntu-18.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
+          - { os: macos-10.15,  target: x86_64-apple-darwin }
+          - { os: macos-11,     target: x86_64-apple-darwin }
+          - { os: windows-2019, target: x86_64-pc-windows-msvc }
+          - { os: windows-2022, target: x86_64-pc-windows-msvc }
+
+    runs-on: ${{matrix.os}}
+    defaults:
+      run:
+        # Add -l for setup-integration-tests → setup-miniconda → automatic
+        # activation of "test" environment.
+        shell: bash -l -eo pipefail {0}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: src/
+
+      - uses: ./src/.github/actions/setup-integration-tests
+        with:
+          python-version: '3.9'
+
+      # Download and extract the installation archive.
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+
+      - if: runner.os != 'Windows'
+        run: tar xzvpf ${{ matrix.target }}.tar.gz
+
+      - if: runner.os == 'Windows'
+        run: Expand-Archive -Path ${{ matrix.target }}.zip -DestinationPath .
+        shell: pwsh
+
+      - run: echo "$PWD" >> "$GITHUB_PATH"
 
       - uses: ./src/.github/actions/run-integration-tests
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,26 @@ development source code and as such may not be routinely kept up to date.
   avoid basic Windows-only pitfalls which we might not otherwise notice in a
   timely fashion.
 
+* Our CI now builds (and tests) standalone installation archives (`.tar.gz` for
+  Linux and macOS, `.zip` for Windows) comprising of:
+
+    1. A `nextstrain` executable containing a bundled Python interpreter + the
+       Python stdlib + the Nextstrain CLI code + its dependencies.
+
+    2. External files (lib, data, etc) that are necessary but can't (for a
+       variety of reasons) be bundled into the executable.
+
+  These installation archives can be downloaded, extracted, and run in-place
+  without even a Python interpreter being installed on the host computer, hence
+  the "standalone" moniker.
+
+  Currently these are for development/testing/experimentation purposes only.
+  We don't distribute them with/as releases or provide an automated means of
+  "installing" or unpacking them; those are ultimate goals, but this is just a
+  first step towards those.  If you try out the standalone archives in the
+  meantime, though, please let us know how it goes (good or bad) by opening an
+  issue with your experience/feedback/questions.
+
 
 # 3.2.5 (23 May 2022)
 

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,0 +1,138 @@
+# This file defines how PyOxidizer application building and packaging is
+# performed.  See PyOxidizer's documentation for details of this configuration
+# file format:
+#
+#   https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_getting_started.html#the-pyoxidizer-bzl-configuration-file
+#
+# The short overview is that it's not-quite-Python but a subset called
+# Starlark.
+#
+# The following variable can be controlled via --var or --var-env.
+#
+# NEXTSTRAIN_CLI_DIST
+#    Specifies a pre-built dist to use for packaging Nextstrain CLI (e.g.
+#    dist/nextstrain_cli-*-py3-none-any.whl) instead of packaging from the
+#    source dir.
+#
+NEXTSTRAIN_CLI_DIST = VARS.get("NEXTSTRAIN_CLI_DIST", ".")
+
+
+# Define how to bundle a Python interpreter + our Python code + shared
+# libraries + other resources into a single executable + an adjacent filesystem
+# "lib/" tree.
+def make_exe():
+    # Obtain the default PythonDistribution for our build target.  We link this
+    # distribution into our produced executable and extract the Python standard
+    # library from it.
+    python_dist = default_python_distribution()
+
+    # This function creates a `PythonPackagingPolicy` instance, which
+    # influences how executables are built and how resources are added to the
+    # executable.  You can customize the default behavior by assigning to
+    # attributes and calling functions.
+    packaging_policy = python_dist.make_python_packaging_policy()
+
+    # Emit both classified resources (PythonModuleSource, etc) and unclassified
+    # "File" resources, but only include the former in packaging by default.
+    # Allow "File" resource to be explicitly added on a case-by-case basis.
+    # See also our exe_resource_policy_decision() and the PyOxidizer docs.¹
+    #
+    # ¹ https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_config_type_python_packaging_policy.html
+    packaging_policy.file_scanner_classify_files = True
+    packaging_policy.file_scanner_emit_files = True
+    packaging_policy.include_classified_resources = True
+    packaging_policy.include_file_resources = False
+    packaging_policy.allow_files = True
+
+    # Embed included resources in the executable by default when possible (e.g.
+    # pure Python modules and data files).  When not possible (e.g. compiled
+    # extension modules) place them on the filesystem in a "lib/" directory
+    # adjacent to the executable.
+    packaging_policy.resources_location = "in-memory"
+    packaging_policy.resources_location_fallback = "filesystem-relative:lib"
+
+    # Invoke a function to make additional packaging decisions for each emitted
+    # resource.
+    packaging_policy.register_resource_callback(exe_resource_policy_decision)
+
+    # Configuration of the embedded Python interpreter.  Setting run_module is
+    # equivalent to `python -m nextstrain.cli …`.
+    python_config = python_dist.make_python_interpreter_config()
+    python_config.run_module = "nextstrain.cli"
+
+    # Produce a PythonExecutable from a Python distribution, embedded
+    # resources, and other options. The returned object represents the
+    # standalone executable that will be built.
+    exe = python_dist.to_python_executable(
+        name = "nextstrain",
+        packaging_policy = packaging_policy,
+        config = python_config)
+
+    # Invoke `pip install` with our Python distribution to install Nextstrain
+    # CLI from source.
+    #
+    # `pip_install()` returns objects representing installed files.
+    # `add_python_resources()` adds these objects to the binary, with a load
+    # location as defined by the packaging policy's resource location
+    # attributes.
+    exe.add_python_resources(exe.pip_install([NEXTSTRAIN_CLI_DIST]))
+
+    # For Windows, always bundle the required Visual C++ Redistributable DLLs
+    # alongside the binary.¹  If they can't be found on the build machine, the
+    # build will error rather than produce a build that's missing these
+    # required DLLs.
+    #
+    # ¹ https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_distributing_windows.html#installing-the-visual-c-redistributable-files-locally-next-to-your-binary
+    #
+    # XXX TODO: Check the licensing requirements of the DLLs this bundles.
+    # They're meant to be redistributed—it's in the name!—and I believe are
+    # even provided for download by the general public, but under what terms?
+    #   -trs, 1 June 2022
+    exe.windows_runtime_dlls_mode = "always"
+
+    return exe
+
+
+def exe_resource_policy_decision(policy, resource):
+    # Some pure Python packages use __file__ to locate their resources (instead
+    # of the importlib APIs) and thus cannot be embedded.  Locate the modules
+    # and data resources of these packages on the filesystem as well.
+    pkgs_requiring_file = ["botocore", "boto3", "docutils.parsers.rst", "docutils.writers"]
+
+    if type(resource) == "PythonModuleSource":
+        if resource.name in pkgs_requiring_file or any([resource.name.startswith(p + ".") for p in pkgs_requiring_file]):
+            resource.add_location = "filesystem-relative:lib"
+
+    if type(resource) in ("PythonPackageResource", "PythonPackageDistributionResource"):
+        if resource.package in pkgs_requiring_file or any([resource.package.startswith(p + ".") for p in pkgs_requiring_file]):
+            resource.add_location = "filesystem-relative:lib"
+
+    # We ignore most "unclassified" Files (include_file_resources = False
+    # above) since our config discovers and emits *both* classified
+    # (PythonModuleSource, etc) and unclassified resources (File) and we prefer
+    # the former.  However, a libffi shared object that ships with the Linux
+    # wheel for cffi doesn't get classified and thus must be caught here as a
+    # plain File.
+    if type(resource) == "File":
+        if resource.path.startswith("cffi.libs/libffi"):
+            print("Adding " + resource.path + " to bundle")
+            resource.add_include = True
+            resource.add_location = "filesystem-relative:lib"
+
+
+# Materialize all the installation artifacts for the executable + external
+# resources into a directory.
+def make_installation(exe):
+    files = FileManifest()
+    files.add_python_resource(".", exe)
+    return files
+
+
+# XXX TODO: Consider also making distribution artifacts from these installation
+# artifacts using Tugger <https://pyoxidizer.readthedocs.io/en/stable/tugger.html>.
+#   -trs, 31 May 2022
+
+
+register_target("exe", make_exe)
+register_target("installation", make_installation, depends=["exe"], default=True)
+resolve_targets()


### PR DESCRIPTION
Produces .tar.gz (Linux, macOS) or .zip (Windows) archives with:

1. A "nextstrain" executable containing a bundled Python interpreter +
   stdlib + the Nextstrain CLI code + our dependencies.

2. External files (lib, data, etc) that are necessary but can't (for a
   variety of reasons) be bundled into the executable.

These installation archives can be downloaded, extracted, and run
in-place without even a Python interpreter being installed on the host
computer, hence the "standalone" moniker.

Currently we won't distribute these with/as releases, but I'd like to
get there and this is the first step.  I think good to be producing them
in CI even now so we can make sure they continue to work and can even
use them as unofficial "daily drivers" ourselves.

### Related issue(s)
Built upon #180 and #181.

### Testing
- [x] CI passes on all platforms
- [x] Works outside of CI on Linux
- [x] Works outside of CI on macOS ([per Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1654119454930279) with @huddlej)
- [x] Works outside of CI on Windows