### PR TITLE
Release to PyPI and GitHub Releases from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+    tags:
+      # Version tags.
+      #
+      # Tags matching this pattern will cause the "release" job below to run,
+      # so edit it carefully!  It should not match arbitrary tags.
+      - "[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
   workflow_dispatch:
 
@@ -293,3 +299,50 @@ jobs:
         run: make -C doc dirhtml
         env:
           SPHINXOPTS: -W --keep-going
+
+  release:
+    # Restricted to version tags by the "on: push: tags: …" config at the top.
+    if: |2
+         github.event_name == 'push'
+      && github.ref_type == 'tag'
+    needs:
+      - build-dist
+      - build-standalone
+      - test-source
+      - test-dist
+      - test-standalone
+      - doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - run: python3 -m pip install --upgrade twine
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: standalone-x86_64-unknown-linux-gnu
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: standalone-x86_64-apple-darwin
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: standalone-x86_64-pc-windows-msvc
+
+      - run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+
+      - run: ./devel/create-github-release "${{github.ref_name}}" dist/* nextstrain-cli-*-standalone-*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -315,6 +315,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      # In actions/checkout@v3 above, annotated tags are intentionally
+      # **overwritten** and converted to a lightweight tag.  Forcibly restore
+      # the annotated tag object from the remote so we can verify/use it later.
+      - run: git fetch --force origin tag "$GITHUB_REF_NAME"
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"

--- a/devel/changes
+++ b/devel/changes
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Extract changelog for a specified version (or __NEXT__ if no version
+specified).
+"""
+from pathlib import Path
+from sys import argv, exit, stdout, stderr
+
+
+CHANGELOG = Path(__file__).parent / "../CHANGES.md"
+
+
+def main(version = "__NEXT__"):
+    with CHANGELOG.open(encoding = "utf-8") as file:
+        for line in file:
+            # Find the heading for this version
+            if line.rstrip("\n") == f"# {version}" or line.startswith(f"# {version} "):
+
+                # Print subsequent lines until we reach the next version heading
+                for line in file:
+                    if line.startswith("# "):
+                        break
+                    stdout.write(line)
+                return 0
+
+        print(f"No changes found for {version!r}.", file = stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    exit(main(*argv[1:]))

--- a/devel/create-github-release
+++ b/devel/create-github-release
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s extglob
+
+devel="$(dirname "$0")"
+
+main() {
+    local version="${1:?version is required}"
+    local commit pre_release
+    shift
+    local -a assets=("$@")
+
+    if [[ ${#assets[@]} -eq 0 ]]; then
+        echo "ERROR: no assets provided" >&2
+        exit 1
+    fi
+
+    # Asserts that $version is an actual tag, not a branch name or other ref.
+    #
+    # Prefixing with refs/tags/ is a bit hacky and suffixing with ^{tag} would
+    # be more proper to restrict to a proper annotated, meant-for-release tag.
+    # While this is dandy in any given clone, in the GitHub Actions context the
+    # annotated tag is intentionally **overwritten** and converted to a
+    # lightweight tag by actions/checkout@v3, which doesn't/can't pass the
+    # muster of ^{tag}.
+    git rev-parse --verify "refs/tags/$version" >/dev/null
+
+    # Translate from tag into commit for `gh release create --target`.
+    commit="$(git rev-parse --verify "$version^{commit}")"
+
+    if is-pre-release "$version"; then
+        pre_release=1
+    fi
+
+    gh release create \
+        "$version" \
+        --repo "${GITHUB_REPOSITORY:-nextstrain/cli}" \
+        --title "$version" \
+        --target "$commit" \
+        ${pre_release:+--prerelease} \
+        --notes-file <(preamble; "$devel"/changes "$version") \
+        "${assets[@]}"
+}
+
+is-pre-release() {
+    # See https://peps.python.org/pep-0440/
+    local version="$1"
+    case "$version" in
+        *@(a|b|rc|c)+([0-9])*)  # alpha, beta, release candidate (PEP 440 pre-releases)
+            return 0;;
+        *.dev+([0-9])*)         # dev release
+            return 0;;
+        *+*)                    # local version
+            return 0;;
+        *)
+            return 1;;
+    esac
+}
+
+preamble() {
+    cat <<~~
+
+_These release notes are automatically extracted from the full [changelog][]._
+
+[changelog]: https://github.com/nextstrain/cli/blob/master/CHANGES.md#readme
+
+~~
+}
+
+main "$@"

--- a/devel/create-github-release
+++ b/devel/create-github-release
@@ -16,14 +16,7 @@ main() {
     fi
 
     # Asserts that $version is an actual tag, not a branch name or other ref.
-    #
-    # Prefixing with refs/tags/ is a bit hacky and suffixing with ^{tag} would
-    # be more proper to restrict to a proper annotated, meant-for-release tag.
-    # While this is dandy in any given clone, in the GitHub Actions context the
-    # annotated tag is intentionally **overwritten** and converted to a
-    # lightweight tag by actions/checkout@v3, which doesn't/can't pass the
-    # muster of ^{tag}.
-    git rev-parse --verify "refs/tags/$version" >/dev/null
+    git rev-parse --verify "$version^{tag}" >/dev/null
 
     # Translate from tag into commit for `gh release create --target`.
     commit="$(git rev-parse --verify "$version^{commit}")"

--- a/devel/release
+++ b/devel/release
@@ -11,6 +11,7 @@ main() {
 
     assert-clean-working-dir
     assert-changelog-has-additions
+    assert-changelog-has-changes-for-next
 
     version="${1:-$(next-version)}"
     echo "New version will be $version."
@@ -18,7 +19,6 @@ main() {
     update-version $version
     update-changelog $version
     commit-and-tag $version
-    build-dist
     unreleased-version $version+git
     remind-to-push $version
 }
@@ -52,6 +52,13 @@ assert-changelog-has-additions() {
 
     if [[ $net_changed -lt 1 ]]; then
         echo "It doesn't look like $(basename "$changes_file") was updated; only $insertions - $deletions = $net_changed line(s) were changed." >&2
+        exit 1
+    fi
+}
+
+assert-changelog-has-changes-for-next() {
+    if [[ -z "$("$devel"/changes __NEXT__)" ]]; then
+        echo "It doesn't look like $(basename "$changes_file") has entries for __NEXT__." >&2
         exit 1
     fi
 }
@@ -101,12 +108,6 @@ commit-and-tag() {
     git tag -sm "version $version" "$version"
 }
 
-build-dist() {
-    rm -rfv dist nextstrain_cli.egg-info
-    python3 setup.py clean
-    python3 setup.py sdist bdist_wheel
-}
-
 unreleased-version() {
     local unreleased_version="$1"
 
@@ -127,9 +128,7 @@ remind-to-push() {
     echo
     echo "   git push origin master tag $version"
     echo
-    echo "You'll also want to upload the built releases to PyPi:"
-    echo
-    echo "   twine upload dist/*"
+    echo "CI will build dists for the release tag and publish them after tests pass."
     echo
 }
 

--- a/devel/release
+++ b/devel/release
@@ -7,10 +7,13 @@ version_file="$repo/nextstrain/cli/__version__.py"
 changes_file="$repo/CHANGES.md"
 
 main() {
+    local version
+
     assert-clean-working-dir
     assert-changelog-has-additions
 
-    version=$(next-version)
+    version="${1:-$(next-version)}"
+    echo "New version will be $version."
 
     update-version $version
     update-changelog $version

--- a/doc/development.md
+++ b/doc/development.md
@@ -51,13 +51,14 @@ run `./bin/nextstrain` to test your local changes without installing them.
 ## Releasing
 
 New releases are made frequently and tagged in git using a [_signed_ tag][].
-The source and wheel (binary) distributions are uploaded to [the nextstrain-cli
-project on PyPi](https://pypi.org/project/nextstrain-cli).
-
 There is a `./devel/release` script which will prepare a new release from your
 local repository.  It ends with instructions for you on how to push the release
-commit/tag and how to upload the built distributions to PyPi.  You'll need [a
-PyPi account][] and [twine][] installed.
+commit/tag.
+
+When a release tag is pushed, the [CI workflow][] builds [source
+distributions][] and [built distributions][] (wheels), tests them, and if tests
+pass, uploads them to [the nextstrain-cli project on
+PyPi](https://pypi.org/project/nextstrain-cli).
 
 ## Tests
 
@@ -102,8 +103,9 @@ safety and correctness.  You can run them like this:
 
 [Semantic Versioning rules]: https://semver.org
 [_signed_ tag]: https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work
-[a PyPi account]: https://pypi.org/account/register/
-[twine]: https://pypi.org/project/twine
+[CI workflow]: ../.github/workflows/ci.yaml
+[source distributions]: https://packaging.python.org/en/latest/glossary/#term-Source-Distribution
+[built distributions]: https://packaging.python.org/en/latest/glossary/#term-Built-Distribution
 [type annotations]: https://www.python.org/dev/peps/pep-0484/
 [mypy]: http://mypy-lang.org/
 [pyright]: https://github.com/microsoft/pyright


### PR DESCRIPTION
### Description of proposed changes
Simplifies the local release process and builds upon other CI work to
make the dists built in CI the basis for everything downstream (tests,
standalone builds, and now PyPI too).  This also means we can include in
GitHub Releases the standalone installation archives, so they're not
squirreled away only in ephemeral Actions artifacts storage.

### Testing
Real test will come with the first releases after this merges, but still, I:

- [x] Tested the release process in a personal fork, with only minor modifications
- [x] Tested all the changelog extraction stuff manually
