### PR TITLE
Include git revision in local version part of CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,13 @@ jobs:
       - run: python3 -m pip install --upgrade pip setuptools wheel
       - run: python3 -m pip install --upgrade build
 
+      # Update version to include local git rev if we're not building a release tag.
+      - if: github.ref_type != 'tag'
+        run: |
+          version="$(./devel/read-version)"
+          git_rev="$(git rev-parse --short @)"
+          ./devel/update-version "${version%%+*}+git.${git_rev}"
+
       # Build dists.
       - run: python3 -m build
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,7 +77,10 @@ development source code and as such may not be routinely kept up to date.
 ## Development
 
 * The source repo now uses a `+git` local version part to distinguish
-  actual releases from installations of unreleased code.
+  actual releases from installations of unreleased code.  Relatedly, the
+  development builds created by CI use a `+git.${commit}` local version part to
+  pin down the specific commit from which they were built.  This is mostly
+  helpful when reading CI logs or downloading the builds from the CI artifacts.
 
 * The CI workflow has seen some significant sprucing up, including sporting a
   more typical lifecycle with separate build and test steps.  This all makes it

--- a/devel/read-version
+++ b/devel/read-version
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+devel = Path(__file__).parent
+repo = devel.parent
+version_file = repo / "nextstrain/cli/__version__.py"
+
+exec(version_file.read_text())
+print(__version__)

--- a/devel/release
+++ b/devel/release
@@ -16,7 +16,7 @@ main() {
     version="${1:-$(next-version)}"
     echo "New version will be $version."
 
-    update-version $version
+    "$devel"/update-version $version
     update-changelog $version
     commit-and-tag $version
     unreleased-version $version+git
@@ -37,7 +37,7 @@ assert-clean-working-dir() {
 }
 
 assert-changelog-has-additions() {
-    local current_version="$(read-version)"
+    local current_version="$("$devel"/read-version)"
     local numstat="$(git diff --numstat "${current_version%%+*}" -- "$changes_file")"
     local insertions deletions rest
 
@@ -64,7 +64,7 @@ assert-changelog-has-changes-for-next() {
 }
 
 next-version() {
-    local current_version="$(read-version)"
+    local current_version="$("$devel"/read-version)"
     current_version="${current_version%%+*}"
 
     read -e -p "Current version is $current_version."$'\n'"New version? " -i "$current_version" new_version
@@ -75,18 +75,6 @@ next-version() {
     fi
 
     echo "$new_version"
-}
-
-update-version() {
-    local new_version="$1"
-    local current_version="$(read-version)"
-
-    perl -pi -e "s/(?<=^__version__ = ')(.*)(?='$)/$new_version/" "$version_file"
-
-    if [[ $new_version != $(read-version) ]]; then
-        echo "Failed to update $version_file!" >&2
-        exit 1
-    fi
 }
 
 update-changelog() {
@@ -112,7 +100,7 @@ unreleased-version() {
     local unreleased_version="$1"
 
     # Add +git local part to mark any further development
-    update-version "$unreleased_version"
+    "$devel"/update-version "$unreleased_version"
 
     git commit -m "dev: Bump version to $unreleased_version" "$version_file"
 }
@@ -130,10 +118,6 @@ remind-to-push() {
     echo
     echo "CI will build dists for the release tag and publish them after tests pass."
     echo
-}
-
-read-version() {
-    python3 -c "exec(open('''$version_file''').read()); print(__version__)"
 }
 
 main "$@"

--- a/devel/update-version
+++ b/devel/update-version
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+devel="$(dirname $0)"
+repo="$devel/.."
+version_file="$repo/nextstrain/cli/__version__.py"
+
+main() {
+    local new_version="${1:?version is required}"
+    local current_version="$("$devel"/read-version)"
+
+    perl -pi -e "s/(?<=^__version__ = ')(.*)(?='$)/$new_version/" "$version_file"
+
+    if [[ $new_version != $("$devel"/read-version) ]]; then
+        echo "Failed to update $version_file!" >&2
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Helps differentiate CI build artifacts from one another.

### Related issue(s)
Based on #186 because of relation to release tags in CI. Related to #183 which introduced the `+git` local part.

### Testing
- [x] CI passes
- [x] Check CI artifacts to make sure they incorporate the extended local part