### PR TITLE
dev: Test standalone installation archive on macOS 12 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,15 +231,13 @@ jobs:
         # pre-installation is convenient for builds.
         #
         # XXX TODO: macOS aarch64 (M1, Apple Silicon, arm64); see above.
-        #
-        # XXX TODO: Include macos-12 once it includes a pre-installed Conda.
-        # <https://github.com/actions/virtual-environments/issues/5623>
         include:
           - { os: ubuntu-18.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           - { os: macos-10.15,  target: x86_64-apple-darwin }
           - { os: macos-11,     target: x86_64-apple-darwin }
+          - { os: macos-12,     target: x86_64-apple-darwin }
           - { os: windows-2019, target: x86_64-pc-windows-msvc }
           - { os: windows-2022, target: x86_64-pc-windows-msvc }
 


### PR DESCRIPTION
The GitHub Actions macOS 12 image version 20220615.1 contains a
pre-installed Miniconda now.

Resolved by <https://github.com/actions/virtual-environments/issues/5623>.