### PR TITLE
runner.aws_batch: Show the timestamp for each log line of the job

### DIFF
--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import signal
 import subprocess
+from datetime import datetime
 from pathlib import Path
 from sys import exit
 from textwrap import dedent
@@ -319,7 +320,14 @@ def print_job_log(entry):
     """
     Print an AWS Batch job log entry.
     """
-    print("[batch]", entry.get("message", ""))
+    msg = entry.get("message", "")
+    ts = entry.get("timestamp", entry.get("ingestionTime")) # milliseconds since epoch
+
+    if ts is not None:
+        ts = datetime.fromtimestamp(round(ts / 1000)).astimezone().isoformat()
+        print(f"[batch] [{ts}] {msg}")
+    else:
+        print(f"[batch] {msg}")
 
 
 def generate_run_id() -> str:


### PR DESCRIPTION
Timestamps are super helpful for making sense of long-running jobs,
which are much of the use case for the AWS Batch runner.  As such, just
enable them across the board rather than making them something you opt
into (i.e. like other troubleshooting/debugging output might be).

The timestamps from AWS have millisecond-level resolution, but that
seemed a touch too fine for the longer run times we're most likely to
encounter.  Output at second-level resolution instead.

Formatted in a standard ISO 8601 format in local time (with timezone
indicated) for user friendliness.

### Testing
- [x] CI passes
- [x] I attached to a variety of jobs and observed the timestamps.