### PR TITLE
Remove our resolve_path() now that we don't support Python 3.5

### DIFF
--- a/bin/nextstrain
+++ b/bin/nextstrain
@@ -4,16 +4,8 @@
 # similar "nextstrain" script automatically created using the entry point
 # feature of setuptools.
 #
-from sys import path, exit, version_info as python_version
+from sys import path, exit
 from pathlib import Path
-
-# Path.resolve() changed default behaviour from 3.5 → 3.6.  We want the
-# stricter (3.5) behaviour in most places, but the "strict" keyword argument
-# didn't exist until 3.6 when the behaviour became optional.
-#
-# This doesn't use nextstrain.cli.utils.resolve_path() because here we're
-# bootstrapping the lib path before loading nextstrain.cli itself.
-strictly = { "strict": True } if python_version > (3,6) else {}
 
 # Try to add our containing package source directory to the Python module
 # search path so that we load nextstrain.cli from there instead of any
@@ -22,7 +14,7 @@ try:
     dev_path = Path(__file__).parent.parent
 
     # Raises an exception if the path doesn't exist.
-    (dev_path / "nextstrain/cli/__init__.py").resolve(**strictly)
+    (dev_path / "nextstrain/cli/__init__.py").resolve(strict = True)
 except:
     pass
 else:

--- a/nextstrain/cli/command/shell.py
+++ b/nextstrain/cli/command/shell.py
@@ -9,7 +9,7 @@ check-setup` to check if Docker is installed and works.
 from .. import runner
 from ..argparse import add_extended_help_flags
 from ..runner import docker
-from ..util import colored, resolve_path, warn
+from ..util import colored, warn
 from ..volume import store_volume
 
 
@@ -63,7 +63,7 @@ def run(opts):
         # command supports (and the only one it makes sense to).
         #   -trs, 25 Sept 2018
         for volume in opts.volumes:
-            print("  /nextstrain/%s is from %s" % (volume.name, resolve_path(volume.src)))
+            print("  /nextstrain/%s is from %s" % (volume.name, volume.src.resolve(strict = True)))
 
         print()
 

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -14,7 +14,7 @@ from time import sleep, time
 from typing import Iterable
 from uuid import uuid4
 from ...types import RunnerTestResults, Tuple
-from ...util import colored, resolve_path, warn
+from ...util import colored, warn
 from ... import config
 from . import jobs, logs, s3
 
@@ -95,7 +95,7 @@ def run(opts, argv, working_volume = None, extra_env = {}, cpus: int = None, mem
     #   -trs, 28 Feb 2022
     assert working_volume is not None
 
-    local_workdir = resolve_path(working_volume.src)
+    local_workdir = working_volume.src.resolve(strict = True)
 
     if opts.attach:
         print_stage("Attaching to Nextstrain AWS Batch Job ID:", opts.attach)

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 from typing import Iterable, List
 from .. import runner, hostenv, config
 from ..types import RunnerTestResults, RunnerTestResultStatus
-from ..util import warn, colored, capture_output, exec_or_return, resolve_path, split_image_name
+from ..util import warn, colored, capture_output, exec_or_return, split_image_name
 from ..volume import store_volume
 from ..__version__ import __version__
 
@@ -118,7 +118,7 @@ def run(opts, argv, working_volume = None, extra_env = {}, cpus: int = None, mem
         *(["--user=%d:%d" % (uid, gid)] if uid and gid else []),
 
         # Map directories to bind mount into the container.
-        *["--volume=%s:/nextstrain/%s" % (resolve_path(v.src), v.name)
+        *["--volume=%s:/nextstrain/%s" % (v.src.resolve(strict = True), v.name)
             for v in opts.volumes
              if v.src is not None],
 

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -202,26 +202,6 @@ def format_usage(doc: str) -> str:
     return indent(dedent(doc.strip("\n")), padding).lstrip()
 
 
-def resolve_path(path: Path) -> Path:
-    """
-    Resolves the given *path* **strictly**, throwing a
-    :class:`FileNotFoundError` if it is not resolvable.
-
-    This function exists only because Path.resolve()'s default behaviour
-    changed from strict to not strict in 3.5 → 3.6.  In most places we want the
-    strict behaviour, but the "strict" keyword argument didn't exist until 3.6
-    when the behaviour became optional (and not the default).
-
-    All this function does is call ``path.resolve()`` on 3.5 and
-    ``path.resolve(strict = True)`` on 3.6.
-    """
-    if python_version >= (3,6):
-        # mypy doesn't know we did a version check
-        return path.resolve(strict = True) # type: ignore
-    else:
-        return path.resolve()
-
-
 def byte_quantity(quantity: str) -> int:
     """
     Parses a string *quantity* consisting of a number, optional whitespace, and


### PR DESCRIPTION
Callers can just use `.resolve(strict = True)` now since we're >=3.6.

### Testing
- [x] CI passes