### PR TITLE
Fix suggested upgrade instructions for standalone installations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ development source code and as such may not be routinely kept up to date.
 
 ## Improvements
 
+* The new version check now links out to the changelog for the latest version
+  so you know what you're gonna get.
+
 * The new version check now detects standalone installations and provides
   correct upgrade instructions.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@ development source code and as such may not be routinely kept up to date.
 
 ## Development
 
+* The `NEXTSTRAIN_CLI_LATEST_VERSION` environment variable can be set to `0` to
+  disable the new version check performed by default during `nextstrain update`
+  and `nextstrain check-setup`.  Other values can be provided to override the
+  result of querying PyPI for the latest version.
+
 * A new command, `debugger`, was added as a tool to help with troubleshooting
   environment and execution context issues.  The only thing it does is invoke
   pdb from within the command's context.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* The new version check now detects standalone installations and provides
+  correct upgrade instructions.
+
 ## Development
 
 * The `NEXTSTRAIN_CLI_LATEST_VERSION` environment variable can be set to `0` to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Development
+
+* A new command, `debugger`, was added as a tool to help with troubleshooting
+  environment and execution context issues.  The only thing it does is invoke
+  pdb from within the command's context.
+
 
 # 4.1.0 (11 July 2022)
 

--- a/doc/upgrading.rst
+++ b/doc/upgrading.rst
@@ -27,6 +27,10 @@ Otherwise, you're using another installation method and running:
     $ nextstrain check-setup
     A new version of nextstrain-cli, X.Y.Z, is available!  You're running A.B.C.
 
+    See what's new in the changelog:
+
+        https://github.com/nextstrain/cli/blob/X.Y.Z/CHANGES.md#readme
+
     Upgrade by running:
 
         [UPGRADE COMMAND]

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 from types    import SimpleNamespace
 
 from .argparse    import HelpFormatter, register_commands, register_default_command
-from .command     import build, view, deploy, remote, shell, update, check_setup, login, logout, whoami, version
+from .command     import build, view, deploy, remote, shell, update, check_setup, login, logout, whoami, version, debugger
 from .errors      import NextstrainCliError
 from .util        import warn
 from .__version__ import __version__
@@ -73,6 +73,7 @@ def make_parser():
         logout,
         whoami,
         version,
+        debugger,
     ]
 
     register_default_command(parser)

--- a/nextstrain/cli/command/debugger.py
+++ b/nextstrain/cli/command/debugger.py
@@ -1,0 +1,15 @@
+"""
+Launch pdb from within the Nextstrain CLI process.
+
+This is a development and troubleshooting tool unnecessary for normal usage.
+"""
+import pdb
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser("debugger", help = "Start a debugger")
+    return parser
+
+
+def run(opts):
+    pdb.set_trace()

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -90,11 +90,18 @@ def check_for_new_version():
 
 def new_version_available():
     """
-    Return the latest version of nextstrain-cli on PyPi if it's newer than the
+    Return the latest version of nextstrain-cli on PyPI if it's newer than the
     currently running version.  Otherwise return None.
+
+    .. envvar:: NEXTSTRAIN_CLI_LATEST_VERSION
+
+        If set, the value will be used as the latest released version of
+        nextstrain-cli and the query to PyPI will be skipped.  Primarily
+        intended for development and testing but can also be used to disable
+        the update check by setting the value to 0.
     """
     this_version   = parse_version(__version__)
-    latest_version = parse_version(fetch_latest_pypi_version("nextstrain-cli"))
+    latest_version = parse_version(os.environ.get("NEXTSTRAIN_CLI_LATEST_VERSION") or fetch_latest_pypi_version("nextstrain-cli"))
 
     return latest_version if latest_version > this_version else None
 

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -58,7 +58,7 @@ def check_for_new_version():
     installed_into_user_site = \
             site.ENABLE_USER_SITE \
         and site.USER_SITE is not None \
-        and __file__.startswith(site.USER_SITE)
+        and (__file__ or "").startswith(site.USER_SITE)
 
     if sys.executable:
         exe_name = Path(sys.executable).name

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -74,6 +74,10 @@ def check_for_new_version():
     if newer_version:
         print("A new version of nextstrain-cli, %s, is available!  You're running %s." % (newer_version, __version__))
         print()
+        print("See what's new in the changelog:")
+        print()
+        print(f"    https://github.com/nextstrain/cli/blob/{newer_version}/CHANGES.md#readme")
+        print()
 
         if standalone_installation():
             print("Upgrade your standalone installation by downloading a new archive from:")

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -60,6 +60,10 @@ def make_exe():
     python_config = python_dist.make_python_interpreter_config()
     python_config.run_module = "nextstrain.cli"
 
+    # Equivalent to: -Xnextstrain-cli-is-standalone, which we use to know if
+    # we're in a standalone installation or not at runtime.
+    python_config.x_options = ["nextstrain-cli-is-standalone"]
+
     # Produce a PythonExecutable from a Python distribution, embedded
     # resources, and other options. The returned object represents the
     # standalone executable that will be built.


### PR DESCRIPTION
### Description of proposed changes
See commit messages for details, but the main change here is fixing the suggested upgrade instructions for standalone installations when a new version is detected by `nextstrain update` or `check-setup`. Probably no one but me is using the standalone installs yet so this is a minor thing… but the reason _I'm_ doing so is to notice bugs just like this. :-)

### Related issue(s)
Related to #182.

### Testing
- [x] CI passes
- [x] Manual testing with `update` and the new `NEXTSTRAIN_CLI_LATEST_VERSION` override. Would love cram tests for this sort of thing—I have a prototype—but not pursuing those for now.