### PR TITLE
dev: Avoid a confusing import binding situation

### DIFF
--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -8,9 +8,8 @@ and Auspice across computing environments such as Docker, Conda, and AWS Batch.
 
 
 import sys
-import argparse
 import traceback
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Action, SUPPRESS
 from textwrap import dedent
 from types    import SimpleNamespace
 
@@ -91,7 +90,7 @@ def register_version_alias(parser):
     argument, so its useful to make that Just Work.
     """
 
-    class run_version_command(argparse.Action):
+    class run_version_command(Action):
         def __call__(self, *args, **kwargs):
             opts = SimpleNamespace(verbose = False)
             sys.exit( version.run(opts) )
@@ -99,5 +98,5 @@ def register_version_alias(parser):
     parser.add_argument(
         "--version",
         nargs  = 0,
-        help   = argparse.SUPPRESS,
+        help   = SUPPRESS,
         action = run_version_command)


### PR DESCRIPTION
### Description of proposed changes

Import shadowing was happening here in the nextstrain.cli module because
of two subtly conflicting imports:

    import argparse
    ...
    from .argparse import ...

The first import binds the "argparse" symbol in nextstrain.cli to the
module from the stdlib, while the second rebinds "argparse" to the
nextstrain.cli.argparse module.¹

Later references in the same file to argparse.X worked because
nextstrain.cli.argparse happened to import (and not exclude from
re-export) the same referenced symbols.

This is confusing, so avoid it.

¹ See <https://docs.python.org/3/reference/import.html#submodules> for
  why.  Note that it only applies here because nextstrain.cli is a
  package with a nextstrain.cli.argparse submodule.  The same import
  statements in, say, nextstrain.cli.foo wouldn't conflict.

What is the goal of this pull request? What does this pull request change?

### Related issue(s)
Related to discussion in https://github.com/nextstrain/augur/pull/1002.

### Testing
- [x] CI passes