### PR TITLE
dev: Enable a wider range of flake8 correctness checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,9 +4,7 @@
 [flake8]
 select =
     E9,     # syntax errors
-    F63,    # syntax warnings (e.g., "==" versus "is")
-    F7,     # type hint logic/syntax errors
-    F82,    # undefined names
+    F       # all pyflakes correctness issues
 
 exclude =
     .git,

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -18,7 +18,7 @@ from .argparse    import HelpFormatter, register_commands, register_default_comm
 from .command     import build, view, deploy, remote, shell, update, check_setup, login, logout, whoami, version, debugger
 from .errors      import NextstrainCliError
 from .util        import warn
-from .__version__ import __version__
+from .__version__ import __version__ # noqa: F401 (for re-export)
 
 
 def run(args):
@@ -36,7 +36,7 @@ def run(args):
         warn(error)
         return 1
 
-    except AssertionError as error:
+    except AssertionError:
         traceback.print_exc()
         warn("\n")
         warn(dedent("""\

--- a/nextstrain/cli/aws/cognito/__init__.py
+++ b/nextstrain/cli/aws/cognito/__init__.py
@@ -14,7 +14,7 @@ with warnings.catch_warnings():
     import jwt
     import jwt.exceptions
 
-from .srp import CognitoSRP, NewPasswordRequiredError
+from .srp import CognitoSRP, NewPasswordRequiredError # noqa: F401 (NewPasswordRequiredError is for re-export)
 
 
 class CognitoError(Exception):

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -22,7 +22,7 @@ from textwrap import indent
 from .. import config
 from ..types import Options
 from ..util import colored, check_for_new_version, remove_prefix, runner_name
-from ..runner import all_runners, default_runner
+from ..runner import all_runners, default_runner # noqa: F401 (it's wrong; we use it in run())
 
 
 def register_parser(subparser):

--- a/nextstrain/cli/command/deploy.py
+++ b/nextstrain/cli/command/deploy.py
@@ -5,7 +5,7 @@
 # and avoids introducing "upload" as a top-level command.
 
 from textwrap import dedent
-from .remote.upload import register_arguments, run, __doc__
+from .remote.upload import register_arguments, run, __doc__ # noqa: F401 (these are for re-export)
 
 def register_parser(subparser):
     parser = subparser.add_parser("deploy", help = "Deploy pathogen build")

--- a/nextstrain/cli/command/login.py
+++ b/nextstrain/cli/command/login.py
@@ -81,7 +81,7 @@ def run(opts):
             username = prompt(getuser)
 
         if password is not None:
-            print(f"Password: (from environment)")
+            print("Password: (from environment)")
         else:
             password = prompt(getpass)
 

--- a/nextstrain/cli/command/whoami.py
+++ b/nextstrain/cli/command/whoami.py
@@ -6,7 +6,6 @@ logged-in user are shown.
 
 Exits with an error if no one is logged in.
 """
-from textwrap import dedent
 from ..authn import current_user
 from ..errors import UserError
 

--- a/nextstrain/cli/remote/nextstrain_dot_org.py
+++ b/nextstrain/cli/remote/nextstrain_dot_org.py
@@ -63,8 +63,8 @@ from email.message import EmailMessage
 from pathlib import Path, PurePosixPath
 from requests.utils import parse_dict_header
 from textwrap import indent
-from typing import Dict, Iterable, List, NamedTuple, NewType, Optional, Tuple, Union
-from urllib.parse import urljoin, urlsplit, quote as urlquote, quote_plus as urlquote_plus
+from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
+from urllib.parse import urljoin, urlsplit, quote as urlquote
 from ..authn import current_user
 from ..errors import UserError
 from ..gzip import GzipCompressingReader
@@ -180,7 +180,7 @@ def upload(url: urllib.parse.ParseResult, local_files: List[Path]) -> Iterable[T
         # appropriate API requests to the group endpoint (which doesn't yet
         # exist).
         #   -trs, 23 Sept 2021
-        raise UserError(f"""
+        raise UserError("""
             Only datasets (v2) and narratives are currently supported for
             upload to nextstrain.org, but other files were given:
 
@@ -622,7 +622,7 @@ def raise_for_status(response: requests.Response) -> None:
                     # enough to handle things like re-seeking streams (which
                     # may not be possible without cooperation).
                     #   -trs, 10 May 2022
-                    raise UserError(f"""
+                    raise UserError("""
                         Login credentials appear to be out of date.
 
                         Please run `nextstrain login --renew` and then retry your command.
@@ -638,21 +638,21 @@ def raise_for_status(response: requests.Response) -> None:
                         and then retry your command.
                         """) from err
             else:
-                raise UserError(f"""
+                raise UserError("""
                     Permission denied.
 
                     Logging in with `nextstrain login` might help?
                     """) from err
 
         elif status == 404:
-            raise UserError(f"""
+            raise UserError("""
                 Remote resource not found.
 
                 Check for typos in the parameters you used?
                 """) from err
 
         elif status in range(500, 600):
-            raise UserError(f"""
+            raise UserError("""
                 The remote server had a problem processing our request.
 
                 Retrying may help if the problem happens to be transient, or

--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -48,7 +48,6 @@ import mimetypes
 import re
 import urllib.parse
 from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError, WaiterError
-from operator import methodcaller
 from os.path import commonprefix
 from pathlib import Path
 from time import time
@@ -205,7 +204,7 @@ def split_url(url: urllib.parse.ParseResult) -> Tuple[S3Bucket, str]:
     try:
         boto3.client("s3").head_bucket(Bucket = bucket.name)
 
-    except ClientError as error:
+    except ClientError:
         raise UserError(f"""
             No bucket exists with the name "{bucket.name}".
 
@@ -349,7 +348,7 @@ def purge_prefix(cloudfront, distribution: dict, origin: dict, prefix: str) -> N
             Id             = invalidation_id,
             DistributionId = distribution_id,
             WaiterConfig   = waiter_config)
-    except WaiterError as e:
+    except WaiterError:
         print("not yet complete")
         warn("Warning: Invalidation %s did not complete within %ds, but it will probably do so soon."
             % (invalidation_id, waiter_config["Delay"] * waiter_config["MaxAttempts"]))

--- a/nextstrain/cli/rst/__init__.py
+++ b/nextstrain/cli/rst/__init__.py
@@ -21,7 +21,6 @@ import re
 from docutils.core import publish_string as convert_rst_to_string, publish_doctree as convert_rst_to_doctree   # type: ignore
 from docutils.parsers.rst.roles import register_local_role
 from docutils.utils import unescape                         # type: ignore
-from urllib.parse import urljoin
 from ..__version__ import __version__ as cli_version
 from .sphinx import TextWriter
 

--- a/nextstrain/cli/rst/sphinx.py
+++ b/nextstrain/cli/rst/sphinx.py
@@ -9,7 +9,6 @@ Subsequent modifications have been made.  These and any future modifications
 are licensed under the MIT license of this project.
 """
 import math
-import os
 import re
 import textwrap
 from itertools import chain, groupby

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -1,7 +1,6 @@
 import argparse
 import builtins
 from argparse import ArgumentParser
-from textwrap import dedent
 from typing import cast, Mapping, List, Union, TYPE_CHECKING
 from . import (
     docker as __docker,

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -5,7 +5,6 @@ Run commands remotely on AWS Batch inside the Nextstrain container image.
 import os
 import shlex
 import signal
-import subprocess
 from datetime import datetime
 from pathlib import Path
 from sys import exit
@@ -13,10 +12,10 @@ from textwrap import dedent
 from time import sleep, time
 from typing import Iterable
 from uuid import uuid4
-from ...types import RunnerTestResults, Tuple
+from ...types import RunnerTestResults
 from ...util import colored, warn
 from ... import config
-from . import jobs, logs, s3
+from . import jobs, s3
 
 
 DEFAULT_JOB = os.environ.get("NEXTSTRAIN_AWS_BATCH_JOB") \

--- a/nextstrain/cli/runner/aws_batch/jobs.py
+++ b/nextstrain/cli/runner/aws_batch/jobs.py
@@ -3,7 +3,6 @@ Job handling for AWS Batch.
 """
 
 import re
-from botocore.exceptions import ClientError
 from copy import deepcopy
 from operator import itemgetter
 from time import time
@@ -46,7 +45,7 @@ class JobState:
 
         try:
             self.state = jobs[0]
-        except IndexError as error:
+        except IndexError:
             raise ValueError("Invalid or unknown job id %s" % self.id) from None
 
     @property

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -7,10 +7,9 @@ import json
 import requests
 import shutil
 import subprocess
-from sys import stdin
 from textwrap import dedent
 from typing import Iterable, List
-from .. import runner, hostenv, config
+from .. import hostenv, config
 from ..types import RunnerTestResults, RunnerTestResultStatus
 from ..util import warn, colored, capture_output, exec_or_return, split_image_name
 from ..volume import store_volume

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -6,7 +6,6 @@ import argparse
 import builtins
 import urllib.parse
 from pathlib import Path
-from types import ModuleType
 from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 from typing_extensions import Protocol
 from .volume import NamedVolume

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -5,13 +5,12 @@ import requests
 import site
 import subprocess
 import sys
-from types import ModuleType
 from typing import Any, Callable, Mapping, List, Optional, Sequence, Tuple, Union, overload
 from typing_extensions import Literal
 from pathlib import Path
 from pkg_resources import parse_version
 from shutil import which
-from sys import exit, stderr, version_info as python_version
+from sys import exit, stderr
 from textwrap import dedent, indent
 from wcmatch.glob import globmatch, GLOBSTAR, EXTGLOB, BRACE, MATCHBASE, NEGATE
 from .__version__ import __version__


### PR DESCRIPTION
### Description of proposed changes
While looking for a flake8 check to catch import shadowing (but alas not
finding what I wanted), I realized that the whole class of "F" checks
from pyflakes are worthwhile correctness checks (in contrast to the "E"
checks, which are mostly stylistic).

Enabling all "F" checks mostly catches a slew of unused imports that
have snuck in over the years.  I would argue these are more correctness
and readability checks than style checks.

### Testing
- [x] CI passes
- [x] Tests pass locally
- [x] Manually exercised functionality of commands implicated by diff