### PR TITLE
docs: Enable the copybutton extension we enable with our Sphinx theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_markdown_tables',
     'sphinxarg.ext',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Our theme enables and configures the copybutton extension, but this only
works if our theme is also enabled as an extension (not just a theme).

### Related issue(s)
Related to https://github.com/nextstrain/sphinx-theme/pull/26.

### Testing
- [ ] CI passes
- [ ] Copy button in RTD preview build