### PR TITLE
Add a debugging mode controlled by NEXTSTRAIN_DEBUG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,16 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Development
+
+* A new debugging mode can be enabled by setting the `NEXTSTRAIN_DEBUG`
+  environment variable to `1` (or another truthy value).  Currently the only
+  effect is to print more information about handled (i.e. anticipated) errors.
+  For example, stack traces and parent exceptions in an exception chain are
+  normally omitted for handled errors, but setting this env var includes them.
+  Future debugging and troubleshooting features, like verbose operation
+  logging, will likely also condition on this new debugging mode.
+
 
 # 4.1.1 (18 July 2022)
 

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -15,6 +15,7 @@ from types    import SimpleNamespace
 
 from .argparse    import HelpFormatter, register_commands, register_default_command
 from .command     import build, view, deploy, remote, shell, update, check_setup, login, logout, whoami, version, debugger
+from .debug       import DEBUGGING
 from .errors      import NextstrainCliError
 from .util        import warn
 from .__version__ import __version__ # noqa: F401 (for re-export)
@@ -32,7 +33,10 @@ def run(args):
         return opts.__command__.run(opts)
 
     except NextstrainCliError as error:
-        warn(error)
+        if DEBUGGING:
+            traceback.print_exc()
+        else:
+            warn(error)
         return 1
 
     except AssertionError:

--- a/nextstrain/cli/debug.py
+++ b/nextstrain/cli/debug.py
@@ -1,0 +1,12 @@
+"""
+Debug flags and utilities.
+
+.. envvar:: NEXTSTRAIN_DEBUG
+
+    Set to a truthy value (e.g. 1) to print more information about (handled)
+    errors.  For example, when this is not set or falsey, stack traces and
+    parent exceptions in an exception chain are omitted from handled errors.
+"""
+from os import environ
+
+DEBUGGING = bool(environ.get("NEXTSTRAIN_DEBUG"))


### PR DESCRIPTION
At the moment, this only enables printing of stack traces and the full
exception chain for handled (i.e. anticipated) errors, which otherwise
were not printed.  In the future, this mode can also control the output
of verbose debugging/troubleshooting logging for more commands.

Related to <https://github.com/nextstrain/cli/issues/201>.

### Testing
- [x] Verified functionality works locally
- [x] CI passes