### PR TITLE
remote.nextstrain_dot_org: Yield resource URL before deletion not after

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,14 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* Using `remote delete` on nextstrain.org now correctly outputs the "Deleting…"
+  message *before* performing each delete, as intended (and as S3 remotes do).
+  Previously, the message was misleadingly output *after* each delete was
+  already performed.
+  ([#209](https://github.com/nextstrain/cli/pull/209))
+
 ## Development
 
 * A new debugging mode can be enabled by setting the `NEXTSTRAIN_DEBUG`

--- a/nextstrain/cli/remote/nextstrain_dot_org.py
+++ b/nextstrain/cli/remote/nextstrain_dot_org.py
@@ -438,13 +438,13 @@ def delete(url: urllib.parse.ParseResult, recursively: bool = False) -> Iterable
             raise UserError(f"Path {path} does not seem to exist")
 
         for resource in resources:
+            yield "nextstrain.org" + str(resource.path)
+
             response = http.delete(api_endpoint(resource.path))
 
             raise_for_status(response)
 
             assert response.status_code == 204
-
-            yield "nextstrain.org" + str(resource.path)
 
 
 def remote_path(url: urllib.parse.ParseResult) -> NormalizedPath:


### PR DESCRIPTION
A pre-action yield matches the messaging of the `remote delete` command
as of "remote delete: Update messaging to match pre-deletion behaviour"
(bb4ab4c) and the behaviour of the S3 remote as of "remote.s3: Rework
delete() to have a similar API to the other commands" (cc86a1a).

The post-action yield was an oversight and bug in the initial remote
implementation.

### Testing
- [x] Ran updated command locally
- [ ] CI passes