### PR TITLE
dev: Stop using macOS 10.15 runners in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             exe: nextstrain
 
-          - os: macos-10.15
+          - os: macos-11
             target: x86_64-apple-darwin
             exe: nextstrain
 
@@ -248,7 +248,6 @@ jobs:
           - { os: ubuntu-18.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
-          - { os: macos-10.15,  target: x86_64-apple-darwin }
           - { os: macos-11,     target: x86_64-apple-darwin }
           - { os: macos-12,     target: x86_64-apple-darwin }
           - { os: windows-2019, target: x86_64-pc-windows-msvc }


### PR DESCRIPTION
They're deprecated by GitHub Actions (as of ~60 days ago), are currently
undergoing scheduled brownouts, and will cease to exist ~30 days from
now.¹  We're on a train where the bridge up ahead is out, so it's time
to get off.

The build-standalone job intentionally used the oldest macOS available
for max compatibility.  While switching to macOS 11 may in theory cause
reduced portability, it also seems that PyOxidizer will by default try
to build for macOS 10.9 (for x86_64) even on newer macOS versions.²  CI
runs and testing will tell.

¹ https://github.com/actions/virtual-environments/issues/5583
² https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_distributing_macos.html#managing-portability-of-built-applications

### Testing
- [x] CI passes
- [x] Review macOS `build-standalone` logs for system build target; is it still 10.9?
- [x] Have someone with an older macOS (@huddlej?) try out the CI artifacts