### PR TITLE
Use nextstrain.org for standalone installation archive URLs

### DIFF
--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -136,7 +136,7 @@ def standalone_installation_archive_url(version: str) -> str:
 
     target_triple = f"{machine}-{vendor}-{os}"
 
-    return f"https://github.com/nextstrain/cli/releases/download/{version}/nextstrain-cli-{version}-standalone-{target_triple}.{archive_format}"
+    return f"https://nextstrain.org/cli/download/{version}/standalone-{target_triple}.{archive_format}"
 
 
 def new_version_available():


### PR DESCRIPTION
…instead of directly linking to github.com.  This indirection is better
branding, but more importantly gives us the ability to use
nextstrain.org to insulate users of older CLI versions from future
changes to where the archives actually live.

See also <https://github.com/nextstrain/nextstrain.org/pull/578>.

### Testing
- [x] CI passes
- [x] Checked this works locally