### PR TITLE
remote download: Use more of the resource path in the local filename

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,55 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+This release contains **a potentially-breaking change** for existing usages of
+`nextstrain remote download`.  The change is described below.
+
+## Improvements
+
+* The local filenames produced by `nextstrain remote download` now include
+  more of the remote dataset/narrative path.  This reduces the potential for
+  ambiguous filenames and makes it easier to copy datasets/narratives between
+  destinations (e.g. from one group to another) while retaining the same path.
+  It is, however, a **potentially-breaking change** if you're relying on the
+  filenames of the downloaded datasets/narratives (e.g. for automation).
+
+  For example, downloading `nextstrain.org/flu/seasonal/h3n2/ha/2y` previously
+  produced the local files:
+
+  ```
+  2y.json
+  2y_root-sequence.json
+  2y_tip-frequencies.json
+  ```
+
+  which could easily conflict with the similarly-named
+  `nextstrain.org/flu/seasonal/h3n2/na/2y`,
+  `nextstrain.org/flu/seasonal/h1n1pdm/ha/2y`, etc.  The downloaded files are
+  now named:
+
+  ```
+  flu_seasonal_h3n2_ha_2y.json
+  flu_seasonal_h3n2_ha_2y_root-sequence.json
+  flu_seasonal_h3n2_ha_2y_tip-frequencies.json
+  ```
+
+  Within groups, filenames are similarly longer but the group name is not
+  included.  For example, downloading `groups/blab/ncov/cross-species/cat`
+  previously produced:
+
+  ```
+  cat.json
+  cat_root-sequence.json
+  cat_tip-frequencies.json
+  ```
+
+  and now produces:
+
+  ```
+  ncov_cross-species_cat.json
+  ncov_cross-species_cat_root-sequence.json
+  ncov_cross-species_cat_tip-frequencies.json
+  ```
 
 # 4.2.0 (29 July 2022)
 

--- a/nextstrain/cli/command/remote/download.py
+++ b/nextstrain/cli/command/remote/download.py
@@ -8,9 +8,9 @@ seasonal influenza datasets::
 
 which creates three files in the current directory::
 
-    2y.json
-    2y_root-sequence.json
-    2y_tip-frequencies.json
+    flu_seasonal_h3n2_ha_2y.json
+    flu_seasonal_h3n2_ha_2y_root-sequence.json
+    flu_seasonal_h3n2_ha_2y_tip-frequencies.json
 
 The --recursively option allows for downloading multiple datasets or narratives
 at once, e.g. to download all the datasets under "ncov/open/…" into an existing
@@ -20,12 +20,12 @@ directory named "sars-cov-2"::
 
 which creates files for each dataset::
 
-    sars-cov-2/global.json
-    sars-cov-2/global_root-sequence.json
-    sars-cov-2/global_tip-frequencies.json
-    sars-cov-2/africa.json
-    sars-cov-2/africa_root-sequence.json
-    sars-cov-2/africa_tip-frequencies.json
+    sars-cov-2/ncov_open_global.json
+    sars-cov-2/ncov_open_global_root-sequence.json
+    sars-cov-2/ncov_open_global_tip-frequencies.json
+    sars-cov-2/ncov_open_africa.json
+    sars-cov-2/ncov_open_africa_root-sequence.json
+    sars-cov-2/ncov_open_africa_tip-frequencies.json
     …
 
 See `nextstrain remote --help` for more information on remote sources.


### PR DESCRIPTION
Includes all of the resource path except for the leading namespace part
(if any), e.g. /groups/X or /staging.

This reduces the potential for ambiguous filenames and makes it easier
to copy datasets/narratives between destinations (e.g. from one group to
another) while retaining the same path.  It is, however, a
**potentially-breaking change** if you're relying on the filenames of
the downloaded datasets/narratives (e.g. for automation).

### Related issue(s)
Related to #169.

### Testing
- [x] Tried downloading various datasets and narratives and observed filenames
- [x] Tests pass locally
- [x] CI passes