### PR TITLE
check-setup: Allow --set-default to optionally take a choice

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,13 @@ This release contains **a potentially-breaking change** for existing usages of
   option continues to be applicable only to the AWS Batch runtime (e.g. the
   `--aws-batch` option).
 
+* The `check-setup` command's `--set-default` option now accepts an optional
+  value to explicitly choose the desired runner (runtime environment),
+  overriding the automatic selection based on what's detected as supported.  If
+  the chosen runner isn't supported, it's still set as the default, but
+  `check-setup` nevertheless exits with an error.
+  ([#216](https://github.com/nextstrain/cli/pull/216))
+
 
 # 4.2.0 (29 July 2022)
 


### PR DESCRIPTION
Providing an explicit choice overrides the automatic selection of the
first passing runner.  If the chosen runner isn't supported, it's still
set as the default, but the command exits with an error.  This is akin
to when check-setup run without --set-default and the already-configured
default is unsupported.

Resolves <https://github.com/nextstrain/cli/issues/110>.

### Testing
- [x] Manually tested `--set-default` with and without options under various conditions
- [x] Local tests pass
- [x] CI passes
