### PR TITLE
Standalone archive installers

### DIFF
--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -1,0 +1,59 @@
+name: Standalone installers
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - bin/standalone-installer-unix
+      - bin/standalone-installer-windows
+
+  pull_request:
+    paths:
+      - bin/standalone-installer-unix
+      - bin/standalone-installer-windows
+
+  # Routinely check that the external resources the installers rely on keep
+  # functioning as expected.
+  schedule:
+    # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  # The goal here is to make sure the installers run successfully on a variety
+  # of OS versions.  We're _not_ testing unreleased standalone builds here—the
+  # installation archives are downloaded from the latest release on GitHub via
+  # nextstrain.org endpoints—which is why this isn't part of CI.  That is, this
+  # is akin to testing `pip install nextstrain-cli` if we wanted to make sure
+  # `pip` worked.
+  #   -trs, 29 August 2022
+  test:
+    name: test (os=${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-18.04
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - macos-11
+          - macos-12
+          - windows-2019
+          - windows-2022
+
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v3
+
+      # Use pipes like are used in the real instructions when the installer is
+      # fetched from nextstrain.org.  This tests that the shell programs work
+      # when they're specifically executed this way.
+      - if: runner.os != 'Windows'
+        run: cat ./bin/standalone-installer-unix | bash
+        shell: bash
+
+      - if: runner.os == 'Windows'
+        run: Get-Content -Raw ./bin/standalone-installer-windows | Invoke-Expression
+        shell: pwsh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,25 @@ This release contains **a potentially-breaking change** for existing usages of
   option continues to be applicable only to the AWS Batch runtime (e.g. the
   `--aws-batch` option).
 
+## Development
+
+* We now provide standalone installers (i.e. shell programs) to download and
+  unpack the standalone installation archives into standard locations,
+  potentially upgrading/overwriting a prior standalone install.  These
+  installers will be served from GitHub directly out of this project's
+  repository via convenience redirects on nextstrain.org.
+
+  These will eventually form the basis for Nextstrain install instructions that
+  don't suffer from Python bootstrapping issues.  As a preview for now, you can
+  play around with the following platform-specific commands:
+
+      curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
+      curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash
+      Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
+
+  A new companion command, `init-shell`, exists to simplify shell configuration
+  (i.e. `PATH` modification) for such installations.
+
 
 # 4.2.0 (29 July 2022)
 

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -1,0 +1,178 @@
+#!/bin/bash
+#
+# Bash program to download the latest Nextstrain CLI standalone installation
+# archive for Linux or macOS, extract it into the current user's app data
+# directory, and check if PATH includes the installation destination.
+#
+# It maintains rough parity with the PowerShell program for Windows,
+# standalone-installer-windows.
+#
+# Set DESTINATION to change the installation location.
+#
+# Set VERSION to change the version downloaded and installed, or pass the
+# desired version as the first argument to this program.
+#
+set -euo pipefail
+shopt -s failglob
+
+: "${NEXTSTRAIN_DOT_ORG:=https://nextstrain.org}"
+
+# Globals declared here to make them more obvious, but set by main() to avoid
+# source ordering requirements and delay execution until the full file is
+# parsed.
+declare KERNEL TARGET DESTINATION VERSION
+
+# Wrap everything in a function which we call at the end to avoid execution of
+# a partially-downloaded program.
+main() {
+    KERNEL="${KERNEL:-$(uname -s)}"
+    TARGET="${TARGET:-$(target-triple)}"
+    DESTINATION="${DESTINATION:-$(destination)}"
+
+    VERSION="${1:-${VERSION:-latest}}"
+
+    local archive archive_url tmp
+
+    archive="standalone-${TARGET}.tar.gz"
+    archive_url="${NEXTSTRAIN_DOT_ORG}/cli/download/${VERSION}/${archive}"
+
+    # Move into a temporary working dir
+    tmp="$(mktemp -d)"
+    if ! debug; then
+        trap "rm -rf $tmp" EXIT
+    fi
+    pushd "$tmp" >/dev/null
+    log "Temporary working directory: $tmp"
+
+    log "Downloading $archive_url"
+    curl "$archive_url" \
+        --fail --show-error --location --proto "=https" \
+        > "$archive"
+
+    log "Extracting $archive"
+    mkdir standalone
+    tar xz$(if-debug v)f "$archive" -C standalone
+
+    if [[ -d "$DESTINATION" ]]; then
+        log "Removing existing $DESTINATION"
+        rm -rf "$DESTINATION"
+    fi
+
+    log "Installing to $DESTINATION"
+    mkdir -p "$(dirname "$DESTINATION")"
+    mv standalone "$DESTINATION"
+
+    popd >/dev/null
+
+    if ! debug; then
+        log "Cleaning up"
+        rm -rf "$tmp"
+    fi
+
+    cat <<~~
+______________________________________________________________________________
+
+Nextstrain CLI ($("$DESTINATION"/nextstrain --version)) installed to $DESTINATION.
+
+~~
+
+    if [[ "$(type -p nextstrain 2>/dev/null)" != "$DESTINATION/nextstrain" ]]; then
+        cat <<~~
+To make the "nextstrain" command available without using its full path,
+please add the following to your shell initialization file (e.g. ~/.bashrc or
+~/.zshrc):
+
+    export PATH="$DESTINATION:\$PATH"
+
+and then logout and login again.  You only need to do this once.
+
+Your default shell appears to be $(default-shell).
+~~
+    fi
+}
+
+target-triple() {
+    local machine vendor os
+
+    machine="$(uname -m)"
+
+    case "$KERNEL" in
+        Linux)
+            [[ "$machine" == x86_64 ]] || die "unsupported architecture: $machine"
+            vendor=unknown
+            os=linux-gnu
+            ;;
+
+        Darwin)
+            [[ "$machine" == x86_64 || "$machine" == arm64 ]] || die "unsupported architecture: $machine"
+            machine=x86_64
+            vendor=apple
+            os=darwin
+            ;;
+
+        *)
+            die "unknown kernel: $KERNEL"
+    esac
+
+    echo "$machine-$vendor-$os"
+}
+
+destination() {
+    local user_data dest
+
+    # Paths from appdirs <https://github.com/ActiveState/appdirs/blob/master/appdirs.py>
+    case "$KERNEL" in
+        Linux)
+            user_data="${XDG_DATA_HOME:-$HOME/.local/share}";;
+
+        Darwin)
+            user_data="$HOME/Library/Application Support";;
+
+        *)
+            die "unknown kernel: $KERNEL"
+    esac
+
+    if [[ ! -d "$user_data" ]]; then
+        log "Current user's app data dir ($user_data) does not exist. Will create it." >&2
+    fi
+
+    echo "$user_data/nextstrain/cli/standalone"
+}
+
+default-shell() {
+    local shell
+
+    case "$KERNEL" in
+        Linux)
+            shell=$(getent passwd "$(id -u)" | awk -F: '{print $NF}');;
+
+        Darwin)
+            shell=$(dscl . -read ~/ UserShell | sed 's/UserShell: //');;
+
+        *)
+            die "unknown kernel: $KERNEL"
+    esac
+
+    basename "$shell"
+}
+
+debug() {
+    [[ -n "${DEBUG:-}" ]]
+}
+
+if-debug() {
+    if debug; then
+        echo "$@"
+    fi
+}
+
+log() {
+    echo "--> $@"
+}
+
+die() {
+    echo "ERROR:" "$@" >&2
+    exit 1
+}
+
+main "$@"

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -77,16 +77,20 @@ Nextstrain CLI ($("$DESTINATION"/nextstrain --version)) installed to $DESTINATIO
 ~~
 
     if [[ "$(type -p nextstrain 2>/dev/null)" != "$DESTINATION/nextstrain" ]]; then
+        local shell rc
+        shell="$(default-shell)"
+        rc="$(shell-rc "$shell")"
+
         cat <<~~
-To make the "nextstrain" command available without using its full path,
-please add the following to your shell initialization file (e.g. ~/.bashrc or
-~/.zshrc):
+To make the "nextstrain" command available in your default shell ($shell)
+without using the full path, please run these two commands now:
 
-    export PATH="$DESTINATION:\$PATH"
+    echo 'source <("$DESTINATION/nextstrain" init-shell $shell)' >> $rc
+    source <("$DESTINATION/nextstrain" init-shell $shell)
 
-and then logout and login again.  You only need to do this once.
-
-Your default shell appears to be $(default-shell).
+The first adds a line to your shell initialization file ($rc) for future
+sessions.  The second sets up your current shell session.  You only need to run
+these once.
 ~~
     fi
 }
@@ -153,7 +157,62 @@ default-shell() {
             die "unknown kernel: $KERNEL"
     esac
 
-    basename "$shell"
+    shell="$(basename "$shell")"
+
+    # Remove any -x.y version from the name
+    echo "${shell%%-*}"
+}
+
+shell-rc() {
+    local shell="$1"
+
+    # Paths below are presumed to be meta-char safe and returned with
+    # unexpanded ~/… prefixes for a nicer appearance in suggested commands,
+    # i.e. expansion of ~ is expected to happen after the user pastes and runs
+    # the commands, rather than here and now.
+    case "$shell" in
+        bash)
+            case "$KERNEL" in
+                Darwin)
+                    # macOS Terminal.app (and iTerm2.app) always launches login
+                    # shells, i.e. for all windows and tabs, so use the login
+                    # initialization file instead of the interactive one
+                    # because Bash (unlike zsh) only reads one or the other.
+                    # Although it's common practice for users to source their
+                    # bashrc from their bash_profile, we can't rely on this.
+                    #
+                    # The order and conditions on files here follows bash(1) §
+                    # INVOCATION:
+                    #
+                    #   After reading [/etc/profile], [bash] looks for
+                    #   ~/.bash_profile, ~/.bash_login, and ~/.profile, in that
+                    #   order, and reads and executes commands from the first one
+                    #   that exists and is readable.
+                    #
+                    if [[ -r ~/.bash_profile ]]; then
+                        echo "~/.bash_profile"
+
+                    elif [[ -r ~/.bash_login ]]; then
+                        echo "~/.bash_login"
+
+                    elif [[ -r ~/.profile ]]; then
+                        echo "~/.profile"
+
+                    else
+                        # If none exist, then we fallback to ~/.bash_profile
+                        # and expect it to be created by our suggested shell
+                        # init commands.
+                        echo "~/.bash_profile"
+                    fi;;
+                *)
+                    echo "~/.bashrc";;
+            esac;;
+        zsh)
+            echo "${ZDOTDIR:-~}/.zshrc";;
+        *)
+            # A decent guess?
+            echo "~/.${shell}rc";;
+    esac
 }
 
 debug() {

--- a/bin/standalone-installer-windows
+++ b/bin/standalone-installer-windows
@@ -1,0 +1,132 @@
+#
+# PowerShell 5+ program to download the latest Nextstrain CLI standalone
+# installation archive for Windows, extract it into the current user's app
+# data directory, and ensure PATH includes the installation destination.
+#
+# It maintains rough parity with the Bash program for Linux and macOS,
+# standalone-installer-unix.
+#
+# Set $env:DESTINATION to change the installation location.
+#
+# Set $env:VERSION to change the version downloaded and installed, or pass the
+# desired version as the first argument to this program.
+#
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = "Stop"
+
+# Wrap everything in a function which we call at the end to avoid execution of
+# a partially-downloaded program.
+function main([string]$version) {
+    $destination = & {
+        if ($env:DESTINATION) {
+            return $env:DESTINATION
+        }
+        if (!$env:LOCALAPPDATA) {
+            throw "LOCALAPPDATA is not set"
+        }
+        if (!(Test-Path $env:LOCALAPPDATA)) {
+            throw "user's LOCALAPPDATA dir does not exist: ${env:LOCALAPPDATA}"
+        }
+        return "${env:LOCALAPPDATA}\nextstrain\cli\standalone"
+    }
+
+    $nextstrain_dot_org = & {
+        if ($env:NEXTSTRAIN_DOT_ORG) { return $env:NEXTSTRAIN_DOT_ORG }
+        return "https://nextstrain.org"
+    }
+
+    if (!$version) {
+        $version = & {
+            if ($env:VERSION) { return $env:VERSION }
+            return "latest"
+        }
+    }
+
+    # XXX TODO: Check for x86_64 arch; i.e. don't pass on 32-bit systems or
+    # non-Intel 64-bit (e.g. arm64).
+
+    $archive = "standalone-x86_64-pc-windows-msvc.zip"
+    $archive_url = "${nextstrain_dot_org}/cli/download/${version}/${archive}"
+
+    # Move into a temporary working dir
+    $tmp = New-Item -Type Directory (Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()))
+    Push-Location $tmp
+    if (!$env:DEBUG) {
+        trap {
+            if ($tmp) {
+                Pop-Location
+                Remove-Item -Recurse -Force $tmp
+            }
+            break
+        }
+    }
+    log "Temporary working directory: $tmp"
+
+    # curl is built into PowerShell Core since version 6, but Windows 10 ships
+    # with Windows PowerShell 5.  orz
+    log "Downloading $archive_url"
+    Invoke-WebRequest $archive_url -OutFile $archive
+
+    log "Extracting $archive"
+    New-Item -Type Directory standalone | Out-Null
+    Expand-Archive -Path $archive -DestinationPath standalone
+
+    if (Test-Path $destination) {
+        log "Removing existing $destination"
+        Remove-Item -Recurse -Force $destination
+    }
+
+    log "Installing to $destination"
+    New-Item -Type Directory -Force $(Split-Path $destination) | Out-Null
+    Move-Item standalone $destination
+
+    # Naively splitting is wrong in the general case, but fine for this check as
+    # long as $destination itself doesn't contain a semi-colon.
+    if ($destination -notin ($env:PATH -split ";")) {
+        log "Prepending $destination to PATH for current user"
+
+        # Update it for this session
+        $env:PATH = "${destination};${env:PATH}"
+
+        # Make it stick for new sessions.
+        #
+        # Note that this intentionally doesn't use $env:PATH to get the
+        # previous value because $env:PATH is a dynamic per-process value
+        # constructed from multiple sources, including the sticky per-user
+        # environment we're modifying here.
+        #
+        # XXX TODO: This expands %VARS% in PATH, e.g. entries like
+        # %SystemRoot%\system32 → C:\Windows\system32, when it roundtrips the
+        # current value.  I think this is basically harmless, and most users
+        # probably have empty user environment PATHs anyway, but worth noting
+        # as a future improvement in case it's not so harmless.  I think to
+        # avoid it we'd have to query and manipulate the registry directly
+        # (instead of using this nice API), like
+        # https://aka.ms/install-powershell.ps1 does.
+        #   -trs, 24 Aug 2022
+        [Environment]::SetEnvironmentVariable("PATH", "$destination;" + [Environment]::GetEnvironmentVariable("PATH", "User"), "User")
+    }
+
+    Pop-Location
+
+    if (!$env:DEBUG) {
+        log "Cleaning up"
+        Remove-Item -Recurse -Force $tmp
+    }
+
+    $version = Invoke-Expression "$destination\nextstrain --version"
+
+    echo @"
+______________________________________________________________________________
+
+Nextstrain CLI ($version) installed to $destination.
+"@
+}
+
+function log {
+    echo "--> $Args"
+}
+
+main @args
+
+# vim: set ft=ps1 :

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -14,7 +14,7 @@ from textwrap import dedent
 from types    import SimpleNamespace
 
 from .argparse    import HelpFormatter, register_commands, register_default_command
-from .command     import build, view, deploy, remote, shell, update, check_setup, login, logout, whoami, version, debugger
+from .command     import build, view, deploy, remote, shell, update, check_setup, login, logout, whoami, version, init_shell, debugger
 from .debug       import DEBUGGING
 from .errors      import NextstrainCliError
 from .util        import warn
@@ -76,6 +76,7 @@ def make_parser():
         logout,
         whoami,
         version,
+        init_shell,
         debugger,
     ]
 

--- a/nextstrain/cli/command/init_shell.py
+++ b/nextstrain/cli/command/init_shell.py
@@ -26,6 +26,7 @@ try:
 except:
     INSTALLATION_PATH = None
 
+# Guard against __doc__ being None to appease the type checkers.
 __doc__ = (__doc__ or "").format(
     INSTALLATION_PATH = (
              shquote(str(INSTALLATION_PATH))

--- a/nextstrain/cli/command/init_shell.py
+++ b/nextstrain/cli/command/init_shell.py
@@ -1,0 +1,102 @@
+"""
+Prints the shell init script for a Nextstrain CLI standalone installation.
+
+If PATH does not contain the expected installation path, emits an appropriate
+``export PATH=…`` statement.  Otherwise, emits only a comment.
+
+Use this command in your shell config with a line like the following::
+
+    source <({INSTALLATION_PATH}/nextstrain init-shell)
+
+Exits with error if run in an non-standalone installation.
+"""
+
+import os
+import shutil
+from pathlib import Path
+from shlex import quote as shquote
+from textwrap import dedent
+from typing import Optional
+from ..errors import UserError
+from ..util import standalone_installation_path
+
+
+try:
+    INSTALLATION_PATH = standalone_installation_path()
+except:
+    INSTALLATION_PATH = None
+
+__doc__ = (__doc__ or "").format(
+    INSTALLATION_PATH = (
+             shquote(str(INSTALLATION_PATH))
+          if INSTALLATION_PATH
+        else "…/path/to"
+    )
+)
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser("init-shell", help = "Print shell init script")
+
+    # We don't currently need to know this as we always emit POSIX shell.
+    # Hedge against needing it in the future, though, by accepting it now so
+    # people won't have to update their shell rcs later.
+    parser.add_argument(
+        "shell",
+        help    = "Shell that's being initialized (e.g. bash, zsh, etc.); "
+                  "currently we always emit POSIX shell syntax but this may change in the future.",
+        nargs   = "?",
+        default = "sh")
+
+    return parser
+
+
+def run(opts):
+    if not INSTALLATION_PATH:
+        raise UserError("No shell init required because this is not a standalone installation.")
+
+    nextstrain = which("nextstrain")
+
+    if not nextstrain or nextstrain.parent != INSTALLATION_PATH:
+        if nextstrain:
+            print(f"# This will mask {nextstrain}")
+            print()
+
+        # This risks duplication if INSTALLATION_PATH is already in PATH but
+        # `nextstrain` is found on an earlier PATH entry.  A duplication-free
+        # solution would be to detect that condition and *move* the existing
+        # INSTALLATION_PATH entry in PATH to the front.  This is easy on the
+        # face of it, so I started drafting an implementation before realizing
+        # it's full of traps and adds lots of complexity, such as:
+        #
+        #   - Proper handling of original paths vs. resolved paths
+        #     (e.g. symlinks, etc).  We'd need to match INSTALLATION_PATH on
+        #     resolved paths but remove the original paths.
+        #
+        #   - Shell syntax for robustly filtering PATH.  Alternately, we could
+        #     filter in Python and emit the static value instead of using $PATH.
+        #     Both are unpleasant for the reason above.
+        #
+        # These are possible, but since this would all be for little gain in
+        # what's already a edge case, let's not sweat it after all.
+        #   -trs, 14 Sept 2022
+        init = """
+            # Add %(INSTALLATION_PATH)s to front of PATH
+            export PATH=%(INSTALLATION_PATH)s"${PATH:+%(pathsep)s}$PATH"
+        """
+    else:
+        init = """
+            # PATH already finds this nextstrain at %(INSTALLATION_PATH)s
+        """
+
+    print(dedent(init.lstrip("\n")) % {
+        "INSTALLATION_PATH": shquote(str(INSTALLATION_PATH)),
+        "pathsep": os.pathsep
+    })
+
+    return 0
+
+
+def which(cmd = "nextstrain") -> Optional[Path]:
+    path = shutil.which(cmd)
+    return Path(path).resolve(strict = True) if path else None

--- a/nextstrain/cli/command/remote/__init__.py
+++ b/nextstrain/cli/command/remote/__init__.py
@@ -27,6 +27,7 @@ see :doc:`docs:reference/data-formats`.
     files (``group-overview.md`` or ``group-logo.png``).
 """
 
+# Guard against __doc__ being None to appease the type checkers.
 __shortdoc__ = (__doc__ or "").strip().splitlines()[0]
 
 

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -132,7 +132,11 @@ def check_for_new_version():
         print()
 
         if standalone_installation():
-            print("Upgrade your standalone installation by downloading a new archive from:")
+            print("Upgrade your standalone installation by running:")
+            print()
+            print(f"    {standalone_installer(newer_version)}")
+            print()
+            print("or by downloading a new archive from:")
             print()
             print(f"    {standalone_installation_archive_url(newer_version)}")
 
@@ -186,6 +190,22 @@ def standalone_installation():
     # if necessary in the future.
     #   -trs, 7 July 2022
     return "nextstrain-cli-is-standalone" in getattr(sys, "_xoptions", {})
+
+
+def standalone_installer(version: str) -> str:
+    system = platform.system()
+
+    if system == "Linux":
+        return f"curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash -s {shquote(version)}"
+
+    elif system == "Darwin":
+        return f"curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash -s {shquote(version)}"
+
+    elif system == "Windows":
+        return 'Invoke-Expression "& { $(Invoke-RestMethod https://nextstrain.org/cli/installer/windows) } %s"' % shquote(version)
+
+    else:
+        raise RuntimeError(f"unknown system {system!r}")
 
 
 def standalone_installation_archive_url(version: str) -> str:

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -192,6 +192,19 @@ def standalone_installation():
     return "nextstrain-cli-is-standalone" in getattr(sys, "_xoptions", {})
 
 
+def standalone_installation_path() -> Optional[Path]:
+    """
+    Return the path of this standalone installation, if applicable.
+    """
+    if not standalone_installation():
+        return None
+
+    if not sys.executable:
+        return None
+
+    return Path(sys.executable).resolve(strict = True).parent
+
+
 def standalone_installer(version: str) -> str:
     system = platform.system()
 


### PR DESCRIPTION
Shell programs to download and unpack the standalone installation archives into standard locations, potentially upgrading/overwriting a prior standalone install.

These programs will be served from GitHub directly out of this repo via convenience redirects on nextstrain.org.

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/582>
Related-to: <https://github.com/nextstrain/docs.nextstrain.org/pull/123>

### Todo

- [x] [Do more to adjust `PATH` on Linux and macOS?](https://github.com/nextstrain/cli/pull/217#issuecomment-1230851374)
- [x] Write tests for these in CI?

### Tests

- [x] Manually tested installer on Linux (@tsibley, you…?)
- [x] Manually tested installer on macOS (you…?)
- [x] Manually tested installer on Windows 10 (@tsibley, you…?)