### PR TITLE
runner.docker: Initial, minimal `setup` support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* `nextstrain setup docker` now downloads the Docker runtime image if it's not
+  already available locally.  This can be a useful initial step after
+  installation to avoid the automatic download on first use.
+  ([#222](https://github.com/nextstrain/cli/pull/222))
+
 
 # 5.0.0.dev0 (6 October 2022)
 


### PR DESCRIPTION
Downloads the image if it's not already available locally, avoiding an awkward download on first use.  It makes more sense to do this in `setup` than to advise folks to run `update` after install.  The update machinery is still used behind the scenes.

Diff best viewed with whitespace ignored.

### Testing
- [x] CI passes, though why wouldn't it?
- [x] Locally tested by hand