### PR TITLE
Add Conda runtime to our CI integration tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yaml
+++ b/.github/actions/run-integration-tests/action.yaml
@@ -12,17 +12,22 @@ description: >-
 runs:
   using: composite
   steps:
-    - name: Run Nextstrain CLI commands
+    - shell: bash -l -eo pipefail {0}
+      run: nextstrain version --verbose
+
+    - if: runner.os != 'macOS' && runner.os != 'Windows'
       shell: bash -l -eo pipefail {0}
-      run: |
-        nextstrain version --verbose
-        nextstrain check-setup --set-default
+      run: nextstrain setup docker
 
-        # XXX TODO: Stop ignoring errors once `update` is improved.  See
-        # <https://github.com/nextstrain/cli/issues/87>.
-        nextstrain update || true
+    - if: runner.os != 'Windows'
+      shell: bash -l -eo pipefail {0}
+      run: nextstrain setup conda
 
-        nextstrain version --verbose
+    - shell: bash -l -eo pipefail {0}
+      run: nextstrain check-setup --set-default
+
+    - shell: bash -l -eo pipefail {0}
+      run: nextstrain version --verbose
 
     - if: runner.os != 'macOS' && runner.os != 'Windows'
       name: Build zika-tutorial with --docker
@@ -30,6 +35,13 @@ runs:
       run: |
         git -C zika-tutorial clean -dfqx
         nextstrain build --docker --cpus 2 zika-tutorial
+
+    - if: runner.os != 'Windows'
+      name: Build zika-tutorial with --conda
+      shell: bash -l -eo pipefail {0}
+      run: |
+        git -C zika-tutorial clean -dfqx
+        nextstrain build --conda --cpus 2 zika-tutorial
 
     - if: runner.os != 'Windows'
       name: Build zika-tutorial with --ambient

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,21 @@ development source code and as such may not be routinely kept up to date.
   runtimes now includes the Conda runtime.
   ([#224](https://github.com/nextstrain/cli/pull/224))
 
+## Bug fixes
+
+* The Conda runtime now runs Micromamba in greater isolation to avoid undesired
+  interactions when a) Nextstrain CLI itself is running inside an
+  externally-activated Conda environment and/or b) user-specific Mamba
+  configuration exists.  This applies to usages of `nextstrain setup` and
+  `nextstrain update` with the Conda runtime.
+  ([#223](https://github.com/nextstrain/cli/pull/223))
+
+## Development
+
+* The Conda runtime is now tested in CI, joining the Docker and ambient
+  runtimes.
+  ([#223](https://github.com/nextstrain/cli/pull/223))
+
 
 # 5.0.0.dev0 (6 October 2022)
 


### PR DESCRIPTION
Splits up the big initial command block to setup runtimes into single-command steps so we can condition runtime setup on host OS support (instead of trying setup on all OSes and ignoring errors).

### Related issue(s)
Based on #222, because `nextstrain setup docker` is handy there.

### Testing
- [x] CI passes