### PR TITLE
Use our new nextstrain-base Conda meta-package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,26 @@ development source code and as such may not be routinely kept up to date.
   runtimes now includes the Conda runtime.
   ([#224](https://github.com/nextstrain/cli/pull/224))
 
+* The Conda runtime now uses the new `nextstrain-base` Conda meta-package
+  instead of using a hardcoded list of packages.
+
+  This decouples Conda runtime updates from Nextstrain CLI updates, as we can
+  make new releases of `nextstrain-base` and users can update to those without
+  upgrading Nextstrain CLI itself.  This brings the update story for the Conda
+  runtime into much better parity with the Docker runtime.
+
+  Using the meta-package also brings increased reproducibility to the runtime,
+  as the package completely locks its full transitive dependency tree.  This
+  means that if version _X_ of `nextstrain-base` worked in the past, it'll
+  still work the same way in the future.
+
+  The `NEXTSTRAIN_CONDA_BASE_PACKAGE` environment variable may be used with
+  `nextstrain setup conda` to install a specific version.  The value is a
+  [Conda package specification][], e.g. `nextstrain-base ==X`.
+  ([#228](https://github.com/nextstrain/cli/pull/228))
+
+[Conda package specification]: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#package-match-specifications
+
 ## Bug fixes
 
 * The Conda runtime now runs Micromamba in greater isolation to avoid undesired
@@ -44,6 +64,14 @@ development source code and as such may not be routinely kept up to date.
   configuration exists.  This applies to usages of `nextstrain setup` and
   `nextstrain update` with the Conda runtime.
   ([#223](https://github.com/nextstrain/cli/pull/223))
+
+* The Conda runtime now configures the appropriate channels during `update` too,
+  not just during `setup`, ensuring package updates are found.
+  ([#228](https://github.com/nextstrain/cli/pull/228))
+
+* The Conda runtime now avoids pinning Python in the isolated environment to
+  allow it to be upgraded by `update`.
+  ([#228](https://github.com/nextstrain/cli/pull/228))
 
 ## Development
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,8 +36,9 @@ development source code and as such may not be routinely kept up to date.
   runtimes now includes the Conda runtime.
   ([#224](https://github.com/nextstrain/cli/pull/224))
 
-* The Conda runtime now uses the new `nextstrain-base` Conda meta-package
-  instead of using a hardcoded list of packages.
+* The Conda runtime now uses the new [`nextstrain-base` Conda
+  meta-package](https://anaconda.org/Nextstrain/nextstrain-base) instead of
+  using a hardcoded list of packages.
 
   This decouples Conda runtime updates from Nextstrain CLI updates, as we can
   make new releases of `nextstrain-base` and users can update to those without

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,16 @@ development source code and as such may not be routinely kept up to date.
   [Conda package specification][], e.g. `nextstrain-base ==X`.
   ([#228](https://github.com/nextstrain/cli/pull/228))
 
+* The Conda runtime now uses a pinned version of Micromamba (currently 0.27.0)
+  so that new releases of the latter can't break `nextstrain setup conda` or
+  `nextstrain update conda` between one day and the next.  The pinned version
+  will be bumped up over time as needed with subsequent releases of Nextstrain
+  CLI.
+
+  The `NEXTSTRAIN_CONDA_MICROMAMBA_VERSION` environment variable may be used
+  with `nextstrain setup conda` to override the built-in pin, either with
+  another specific version or `latest`.
+
 [Conda package specification]: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#package-match-specifications
 
 ## Bug fixes

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -20,6 +20,15 @@ Environment variables
     Conda meta-package name to use for the Nextstrain base runtime dependencies.
 
     Defaults to ``nextstrain-base``.
+
+.. envvar:: NEXTSTRAIN_CONDA_MICROMAMBA_VERSION
+
+    Version of Micromamba to use for setup and upgrade of the Conda runtime
+    env.  Must be a version available from the `conda-forge channel
+    <https://anaconda.org/conda-forge/micromamba/>`__, or the special string
+    ``latest``.
+
+    Defaults to ``0.27.0``.
 """
 
 import json
@@ -33,7 +42,7 @@ import tarfile
 import traceback
 from pathlib import Path, PurePosixPath
 from typing import Iterable
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote as urlquote
 from ..errors import InternalError
 from ..paths import RUNTIMES
 from ..types import RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
@@ -47,6 +56,10 @@ PREFIX_BIN = PREFIX / "bin"
 
 MICROMAMBA_ROOT = RUNTIME_ROOT / "micromamba/"
 MICROMAMBA      = MICROMAMBA_ROOT / "bin/micromamba"
+
+# If you update the version pin below, please update the docstring above too.
+MICROMAMBA_VERSION = os.environ.get("NEXTSTRAIN_CONDA_MICROMAMBA_VERSION") \
+                  or "0.27.0"
 
 NEXTSTRAIN_CHANNEL = os.environ.get("NEXTSTRAIN_CONDA_CHANNEL") \
                   or "nextstrain"
@@ -125,8 +138,8 @@ def setup_micromamba(dry_run: bool = False, force: bool = False) -> bool:
         if not dry_run:
             shutil.rmtree(str(MICROMAMBA_ROOT))
 
-    # Query for latest Micromamba release
-    response = requests.get("https://api.anaconda.org/release/conda-forge/micromamba/latest")
+    # Query for Micromamba release
+    response = requests.get(f"https://api.anaconda.org/release/conda-forge/micromamba/{urlquote(MICROMAMBA_VERSION)}")
     response.raise_for_status()
 
     dists = response.json().get("distributions", [])

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -126,10 +126,10 @@ def setup_micromamba(dry_run: bool = False, force: bool = False) -> bool:
             shutil.rmtree(str(MICROMAMBA_ROOT))
 
     # Query for latest Micromamba release
-    dists = (
-        requests.get("https://api.anaconda.org/release/conda-forge/micromamba/latest")
-            .json()
-            .get("distributions", []))
+    response = requests.get("https://api.anaconda.org/release/conda-forge/micromamba/latest")
+    response.raise_for_status()
+
+    dists = response.json().get("distributions", [])
 
     system = platform.system()
     machine = platform.machine()
@@ -159,6 +159,7 @@ def setup_micromamba(dry_run: bool = False, force: bool = False) -> bool:
 
     if not dry_run:
         response = requests.get(dist_url, stream = True)
+        response.raise_for_status()
         content_type = response.headers["Content-Type"]
 
         assert content_type == "application/x-tar", \

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -273,6 +273,10 @@ def micromamba(*args, add_prefix: bool = True) -> None:
             "--channel", NEXTSTRAIN_CHANNEL,
             "--channel", "conda-forge",
             "--channel", "bioconda",
+
+            # Don't automatically pin Python so nextstrain-base deps can change
+            # it on upgrade.
+            "--no-py-pin",
         )
 
     env = {


### PR DESCRIPTION
See commit messages. Main change is in the title.

Related to <https://github.com/nextstrain/conda-base/pull/1>.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass (~won't pass until https://github.com/nextstrain/conda-base/pull/1 is merged so the default channel works~, ah, I was thinking #223 was merged, but it's not yet _[update: it is now]_)
- [x] Local tests pass
- [x] Manual testing with `NEXTSTRAIN_CONDA_CHANNEL=nextstrain/label/pull-1 nextstrain setup conda` and `NEXTSTRAIN_CONDA_CHANNEL=nextstrain/label/branch-initial nextstrain update conda`

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
