### PR TITLE
Add an `authorization` command to ease direct requests to nextstrain.org's web API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Development
+
+* A new `nextstrain authorization` command makes it easier to generate direct
+  requests to nextstrain.org's web API using the same credentials as the CLI.
+  ([#229](https://github.com/nextstrain/cli/pull/229))
+
 
 # 5.0.0.dev1 (25 October 2022)
 

--- a/doc/commands/authorization.rst
+++ b/doc/commands/authorization.rst
@@ -1,0 +1,9 @@
+========================
+nextstrain authorization
+========================
+
+.. argparse::
+    :module: nextstrain.cli
+    :func: make_parser
+    :prog: nextstrain
+    :path: authorization

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,6 +52,7 @@ Table of Contents
     commands/login
     commands/logout
     commands/whoami
+    commands/authorization
     commands/version
 
 .. toctree::

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -14,7 +14,7 @@ from textwrap import dedent
 from types    import SimpleNamespace
 
 from .argparse    import HelpFormatter, register_commands, register_default_command
-from .command     import build, view, deploy, remote, shell, update, setup, check_setup, login, logout, whoami, version, init_shell, debugger
+from .command     import build, view, deploy, remote, shell, update, setup, check_setup, login, logout, whoami, version, init_shell, authorization, debugger
 from .debug       import DEBUGGING
 from .errors      import NextstrainCliError
 from .util        import warn
@@ -78,6 +78,7 @@ def make_parser():
         whoami,
         version,
         init_shell,
+        authorization,
         debugger,
     ]
 

--- a/nextstrain/cli/command/authorization.py
+++ b/nextstrain/cli/command/authorization.py
@@ -1,0 +1,29 @@
+"""
+Produce an Authorization header appropriate for nextstrain.org's web API.
+
+This is a development tool unnecessary for normal usage.  It's useful for
+directly making API requests to nextstrain.org with ``curl`` or similar
+commands.  For example::
+
+    curl -si https://nextstrain.org/whoami \\
+        --header "Accept: application/json" \\
+        --header @<(nextstrain authorization)
+
+Exits with an error if no one is logged in.
+"""
+from ..authn import current_user
+from ..errors import UserError
+
+
+def register_parser(subparser):
+    parser = subparser.add_parser("authorization", help = "Print an HTTP Authorization header")
+    return parser
+
+
+def run(opts):
+    user = current_user()
+
+    if not user:
+        raise UserError("Not logged in.")
+
+    print(f"Authorization: {user.http_authorization}")


### PR DESCRIPTION
- [x] Manually tested logged in and logged out cases and the example `curl` command in `nextstrain authorization --help` output
- [x] `pytest` passes locally
- [x] Checks pass
