### PR TITLE
runner.conda: Bump Micromamba version from 0.27.0 to 1.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Development
+
+* The Conda runtime now uses Micromamba 1.0.0 (an upgrade from 0.27.0).
+  ([#233](https://github.com/nextstrain/cli/pull/233))
+
 
 # 5.0.1 (1 November 2022)
 

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -28,7 +28,7 @@ Environment variables
     <https://anaconda.org/conda-forge/micromamba/>`__, or the special string
     ``latest``.
 
-    Defaults to ``0.27.0``.
+    Defaults to ``1.0.0``.
 """
 
 import json
@@ -59,7 +59,7 @@ MICROMAMBA      = MICROMAMBA_ROOT / "bin/micromamba"
 
 # If you update the version pin below, please update the docstring above too.
 MICROMAMBA_VERSION = os.environ.get("NEXTSTRAIN_CONDA_MICROMAMBA_VERSION") \
-                  or "0.27.0"
+                  or "1.0.0"
 
 NEXTSTRAIN_CHANNEL = os.environ.get("NEXTSTRAIN_CONDA_CHANNEL") \
                   or "nextstrain"


### PR DESCRIPTION
It'll be good to be using a 1.0 release!

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
