### PR TITLE
Fix CI (again)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,11 +3,15 @@
 
 [flake8]
 select =
-    E9,     # syntax errors
-    F       # all pyflakes correctness issues
+    # syntax errors
+    E9,
+
+    # all pyflakes correctness issues
+    F,
 
 extend-ignore =
-    F541    # allow f-strings without any placeholders
+    # allow f-strings without any placeholders
+    F541,
 
 exclude =
     .git,

--- a/nextstrain/cli/runner/aws_batch/logs.py
+++ b/nextstrain/cli/runner/aws_batch/logs.py
@@ -4,7 +4,7 @@ Log handling for AWS Batch jobs.
 
 import threading
 from botocore.exceptions import ClientError, ConnectionError as BotocoreConnectionError
-from typing import Any, Callable, Dict, Generator, MutableSet
+from typing import Any, Callable, Dict, Generator, MutableSet # noqa: F401 (it's wrong; we use it in a type comment)
 from ... import aws
 
 


### PR DESCRIPTION
Fixes syntax of the flake8 config file.

The trailing comments were apparently bogus this whole time!  The
configuration documentation does mention this¹, though not sure it did
at the time I wrote the config initially.  In any case: oops.

flake8 version 6.0.0, released earlier today, started validating the
config and thus detecting the erroneous entries, which made our CI start
to fail with:

    ValueError: Error code '#' supplied to 'extend-ignore' option does
    not match '^[A-Z]{1,3}[0-9]{0,3}$'

Failures were limited to Python ≥3.8, as flake8 6.0.0 bumped its minimum
Python dep, so older Python versions kept using older flake8 versions,
but the syntax error affected them nevertheless.

¹ https://flake8.pycqa.org/en/latest/user/configuration.html

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

CI failures [noticed in an unrelated PR](https://github.com/nextstrain/cli/pull/238#issuecomment-1325665456).

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
