### PR TITLE
view: Support narratives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,44 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+This release contains a **potentially-breaking change** for existing usages of
+`nextstrain view`, though we expect the change to impact very few usages.  The
+change is described below.
+
+## Features
+
+* `nextstrain view` now supports viewing narratives, as was always intended.
+  Previously the launched Auspice would either show baked in test narratives or
+  no narratives at all, depending on the Auspice version in the runtime.
+  ([#240][])
+
+* `nextstrain view` now supports being given more kinds of paths, including
+  paths to a specific dataset or narrative file and paths to directories
+  containing _auspice/_ and/or _narratives/_ subdirectories.
+
+  This is a **potentially-breaking change**, as `nextstrain view <dir>` will
+  now prefer to show datasets from _`<dir>`/auspice/_ if that subdirectory
+  exists.  Previously it would only ever look for datasets in the given
+  _`<dir>`_.  We expect this to change behaviour for very few usages as it only
+  affects situations where _`<dir>`_ contains both datasets and an _auspice/_
+  directory.
+
+  See `nextstrain view --help` for more details on the kinds of paths
+  supported.
+  ([#240][])
+
+* `nextstrain view` now automatically opens Auspice in a new browser tab (or
+  window) by default when possible.
+
+  If a specific dataset or narrative file was given as the path to `nextstrain
+  view`, then that dataset or narrative is opened.  Otherwise, if there's only
+  a single dataset or narrative available in the directory path given to
+  `nextstrain view`, then it is opened.  Otherwise, Auspice's listing of
+  available datasets and narratives is opened.
+  ([#240][])
+
+[#240]: https://github.com/nextstrain/cli/pull/240
+
 ## Development
 
 * The Conda runtime now uses Micromamba 1.0.0 (an upgrade from 0.27.0).

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -38,6 +38,9 @@ If your pathogen build directory follows our conventional layout by containing
 an **auspice** directory (and optionally a **narratives** directory), then you
 can give ``nextstrain view`` the same path as you do ``nextstrain build``.
 
+Note that by convention files named **README.md** or **group-overview.md** will
+be ignored for the purposes of finding available narratives.
+
 .. _dataset (.json) file: https://docs.nextstrain.org/page/reference/glossary.html#term-dataset
 .. _narrative (.md) file: https://docs.nextstrain.org/page/reference/glossary.html#term-narrative
 """


### PR DESCRIPTION
See commit messages for details. The summaries:

1. 6950f2f view: Support narratives
2. 334ab6d view: Open a browser automatically
3. 77f2975 view: Adjust dataset_paths() and narrative_paths() to take a list of file paths
4. de0ef0c view: Accept paths to a specific dataset or narrative file

### Related issue(s)

#128 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually tested various invocations with a variety of circumstances
- [x] Tests pass locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
