### PR TITLE
standalone-installer-unix: Check we can exec the installed binary…

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -69,10 +69,16 @@ main() {
         rm -rf "$tmp"
     fi
 
+    log "Checking installation"
+    local installed_version
+    if ! installed_version="$("$DESTINATION"/nextstrain --version)"; then
+        die "installation check failed: unable to run \`"$DESTINATION"/nextstrain --version\`; look for error message above."
+    fi
+
     cat <<~~
 ______________________________________________________________________________
 
-Nextstrain CLI ($("$DESTINATION"/nextstrain --version)) installed to $DESTINATION.
+Nextstrain CLI ($installed_version) installed to $DESTINATION.
 
 ~~
 


### PR DESCRIPTION
…and error if we can't.  Previously, failures to exec the installed binary would be ignored and the installer would continue to suggest the final shell setup steps (which would result in errors when run).

This catches an observed issue when installing our x86_64 binary on an arm64 Mac before Rosetta 2 is enabled.

    bash: line 72: /Users/blab/.nextstrain/cli-standalone/nextstrain: Bad CPU type in executable
    ______________________________________________________________________________

    Nextstrain CLI () installed to /Users/blab/.nextstrain/cli-standalone.

Stopping early is better than suggesting bad next steps bound to fail.

Related-to: https://github.com/nextstrain/docs.nextstrain.org/pull/147

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Invoked on Linux with `KERNEL=Darwin` and it detected the issue
- [x] Invoked on macOS with `TARGET=x86_64-unknown-linux-gnu` and it detected the issue; can't test with `TARGET=x86_64-apple-darwin` as Rosetta 2 is now enabled on the Mac this arose on
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
