### PR TITLE
Support older glibc versions (e.g. CentOS 7) for standalone installations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,15 +119,10 @@ jobs:
       run:
         shell: bash
     steps:
-      # Install pyoxidizer.
-      #
-      # Even though it's a Rust project, the easiest cross-platform way to
-      # install it is via pip since they publish wheels with the binaries. :-)
       # Note that this Python version doesn't impact the actual build.
       - uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-      - run: pip install 'pyoxidizer !=0.23.0'
 
       # Build the executable + necessary external files from the dists.
       - uses: actions/checkout@v3
@@ -149,7 +144,7 @@ jobs:
           done
 
       - run: |
-          pyoxidizer build \
+          ./devel/pyoxidizer build \
             --release \
             --target-triple ${{ matrix.target }} \
             --var NEXTSTRAIN_CLI_DIST "$DIST"
@@ -160,7 +155,7 @@ jobs:
       # if it fails.  Currently it only works on Linux, though it's supposed to
       # eventually work on all platforms supported by pyoxidizer.
       - if: runner.os == 'Linux'
-        run: pyoxidizer analyze build/${{ matrix.target }}/release/installation/${{ matrix.exe }}
+        run: ./devel/pyoxidizer analyze build/${{ matrix.target }}/release/installation/${{ matrix.exe }}
         continue-on-error: true
 
       # XXX TODO: Review and report on licensing of all the stuff built into

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 environment*
 
+# Automatically-managed PyOxidizer binaries (e.g. pyoxidizer-0.22.0-py3-none-manylinux2010_x86_64).
+/devel/pyoxidizer-[0-9]*
+
 # Package build dirs
 /build/
 /dist/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,31 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* The standalone installation archives used by the standalone installer will
+  now work on even older Linux distributions:
+
+  |distro       |now    |was    |
+  |-------------|-------|-------|
+  |Ubuntu       |14\.04 |18\.04 |
+  |Debian       |8      |10     |
+  |RHEL/CentOS  |7      |8      |
+  |Fedora       |19     |28     |
+  |OpenSUSE     |12\.3  |15\.3  |
+
+  If you've previously encountered errors like the following:
+
+      /lib64/libc.so.6: version `GLIBC_2.27' not found (required by […]/.nextstrain/cli-standalone/nextstrain)
+
+  when using the standalone installer (or standalone archives directly), i.e.:
+
+      curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
+
+  then this change should resolve that error!  The new minimum required glibc
+  version is 2.17 (was 2.27 previously).
+  ([#243](https://github.com/nextstrain/cli/pull/243))
+
 
 # 6.0.0 (13 December 2022)
 

--- a/devel/pyoxidizer
+++ b/devel/pyoxidizer
@@ -15,7 +15,16 @@ main() {
         echo "--> Downloaded PyOxidizer binary to $pyoxidizer" >&2
     fi
 
-    exec "$pyoxidizer" "$@"
+    # On Linux, exec into a manylinux container with an old glibc version.
+    # These manylinux images are used in the Python packaging ecosystem to
+    # build widely-compatible binary packages (wheels).
+    #
+    # https://github.com/pypa/manylinux#readme
+    if [[ "$(platform-system)" == Linux ]]; then
+        exec "$devel"/within-container quay.io/pypa/manylinux2014_x86_64 "$pyoxidizer" "$@"
+    else
+        exec "$pyoxidizer" "$@"
+    fi
 }
 
 locate() {

--- a/devel/pyoxidizer
+++ b/devel/pyoxidizer
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s extglob failglob
+
+devel="$(dirname "$0")"
+
+main() {
+    local pyoxidizer
+
+    if pyoxidizer="$(locate 2>/dev/null)"; then
+        echo "--> Located existing PyOxidizer binary at $pyoxidizer" >&2
+    else
+        echo "--> Downloading PyOxidizer binary…" >&2
+        pyoxidizer="$(download)"
+        echo "--> Downloaded PyOxidizer binary to $pyoxidizer" >&2
+    fi
+
+    exec "$pyoxidizer" "$@"
+}
+
+locate() {
+    # Locate existing local copy of pyoxidizer.
+    echo "$devel"/pyoxidizer-[0-9]*_"$(platform-machine)"?(.exe) | head -n1
+}
+
+download() {
+    # Download pyoxidizer and return the path to it.
+    #
+    # Even though it's a Rust project, the easiest cross-platform way to
+    # download it is via pip since they publish wheels with the binaries. :-)
+    # Using Pip also allows us to piggy back on the version specification
+    # system and platform-specific bits of a package manager/registry
+    # ecosystem.
+    local tmp
+    tmp="$(mktemp -d)"
+    trap "rm -rf \"$tmp\"" EXIT
+
+    python3 -m pip download \
+        --disable-pip-version-check \
+        --quiet \
+        --no-deps \
+        --dest "$tmp" \
+        'pyoxidizer !=0.23.0' \
+            >&2
+
+    local wheel binary
+    wheel=("$tmp"/pyoxidizer-[0-9]*.whl)
+    binary="$(basename "$wheel" .whl)"
+
+    if [[ "$(platform-system)" == Windows ]]; then
+        binary+=.exe
+    fi
+
+    unzip -p "$wheel" '*/scripts/pyoxidizer*' > "$devel/$binary"
+    chmod +x "$devel/$binary"
+
+    echo "$devel/$binary"
+}
+
+platform-machine() {
+    python3 -c 'import platform; print(platform.machine())'
+}
+
+platform-system() {
+    python3 -c 'import platform; print(platform.system())'
+}
+
+main "$@"

--- a/devel/within-container
+++ b/devel/within-container
@@ -1,0 +1,11 @@
+#!/bin/bash
+# usage: devel/within-container <image> [<argv0> [<argv1> [...]]]
+set -euo pipefail
+
+exec docker run \
+  --rm \
+  --env HOME=/tmp \
+  --volume "$PWD:$PWD" \
+  --workdir "$PWD" \
+  --user "$(id -u):$(id -g)" \
+  "$@"


### PR DESCRIPTION
Improves our support of even older glibc and distro versions:

```diff
--- before
+++ after
@@ -27,24 +27,24 @@ libutil.so.1
 Symbol Versioning
 =================
 
 gcc
 -----
 
 Minimum Version: 4.2.0
 Minimum Distro Versions:
   Debian 7
   Fedora 16
   OpenSUSE 11.4
   RHEL 6
   Ubuntu 12.04
 
 glibc
 -----
 
-Minimum Version: 2.27
+Minimum Version: 2.17
 Minimum Distro Versions:
-  Debian 10
-  Fedora 28
-  No known OpenSUSE versions supported
-  RHEL 8
-  Ubuntu 18.04
+  Debian 8
+  Fedora 19
+  OpenSUSE 12.3
+  RHEL 7
+  Ubuntu 14.04
```

See commit messages for details.

### Related issue(s)

- #234 
- CDC's issues with CentOS 7

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Confirm minimum glibc versions get older
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
