### PR TITLE
view: Fix --open so it works when using our standalone executable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,13 @@ development source code and as such may not be routinely kept up to date.
   version is 2.17 (was 2.27 previously).
   ([#243](https://github.com/nextstrain/cli/pull/243))
 
+## Bug fixes
+
+* The automatic opening of a browser tab (or window) by `nextstrain view`—a
+  feature introduced in the last release (6.0.0)—now also works for standalone
+  installations.
+  ([#244](https://github.com/nextstrain/cli/pull/244))
+
 
 # 6.0.0 (13 December 2022)
 

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,7 @@ setup(
             "nextstrain-sphinx-theme>=2022.5",
             "pytest; python_version != '3.9'",
             "pytest !=7.0.0; python_version == '3.9'",
+            "pytest-forked",
             "recommonmark",
             "sphinx>=3",
             "sphinx-argparse ~=0.3",

--- a/tests/open_browser.py
+++ b/tests/open_browser.py
@@ -1,0 +1,34 @@
+"""
+Test nextstrain.cli.view.open_browser() works under different multiprocessing
+start methods.
+
+This file is loaded in the global pytest process, but each test function is
+marked to run in its own (forked) subprocess, so we modify relevant global
+state in each function.
+"""
+import multiprocessing
+import os
+import pytest
+
+if os.name != "posix":
+    pytest.skip("@pytest.mark.forked requires a POSIX platform", allow_module_level = True)
+
+
+@pytest.mark.forked
+def pytest_open_browser_fork():
+    multiprocessing.set_start_method("fork")
+    _open_browser()
+
+
+@pytest.mark.forked
+def pytest_open_browser_spawn():
+    multiprocessing.set_start_method("spawn")
+    _open_browser()
+
+
+def _open_browser():
+    # Must do this early, before nextstrain.cli.command.view is loaded
+    os.environ["BROWSER"] = "echo"
+
+    from nextstrain.cli.command.view import open_browser
+    assert open_browser("https://nextstrain.org")


### PR DESCRIPTION
Long story short, the multiprocess "spawn" start method doesn't (and maybe can't) work for our standalone executable on Unix systems, so we can't use it unconditionally to avoid bugs arising from "fork" vs. "spawn" on different platforms.  See the bug this resolves (below) for all the details.

Instead, use the default platform-dependent start method and try to catch future bugs with tests that exercise open_browser() under both "fork" and "spawn".

Resolves <https://github.com/nextstrain/cli/issues/242>.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tests pass locally
- [x] Non-standalone works locally
- [x] Standalone works locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
