### PR TITLE
Suppress new warning from cryptography 39 about deprecated Python 3.6 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,20 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+_See also changes in 6.0.1 which was an unreleased version._
+
+## Bug fixes
+
+* A new deprecation warning from the `cryptography` module (version 39) when
+  running on Python 3.6 is now suppressed as it's just noise to an end user.
+  This probably moves us closer to dropping 3.6 support ourselves, but it's not
+  so onerous yet.
+  ([#246](https://github.com/nextstrain/cli/issues/246))
+
 
 # 6.0.1 (3 January 2023)
+
+_Unreleased due to [test failures](https://github.com/nextstrain/cli/issues/245). Changes first released as part of 6.0.2._
 
 ## Improvements
 

--- a/nextstrain/cli/aws/cognito/__init__.py
+++ b/nextstrain/cli/aws/cognito/__init__.py
@@ -4,11 +4,11 @@ AWS Cognito helpers.
 import boto3
 import warnings
 
-# Ignore noisy warning from cryptography 37.0.0 about deprecated support for Python 3.6.
+# Ignore noisy warning from cryptography 37.0.0 and 39.0.0 about deprecated support for Python 3.6.
 with warnings.catch_warnings():
     warnings.filterwarnings(
         "ignore",
-        message  = "Python 3\\.6 is no longer supported by the Python core team\\. Therefore, support for it is deprecated in cryptography and will be removed in a future release\\.",
+        message  = "Python 3\\.6 is no longer supported by the Python core team\\. Therefore, support for it is deprecated in cryptography",
         category = UserWarning)
 
     import jwt


### PR DESCRIPTION
Version 39 changed the wording of the deprecation warning added by version 37.  39 still works on Python 3.6 but now warns that version 40 will be the last to include support.  Without supression, the deprecation causes loud, user-visible warnings when running any command:

    Python 3.6 is no longer supported by the Python core team. Therefore,
    support for it is deprecated in cryptography. The next release of
    cryptography (40.0) will be the last to support Python 3.6.

This is more reason to drop 3.6 ourselves eventually as we'll not want to be using an older and older cryptography release.  In the meantime, however, squash the warning since it does no good for end users.

Resolves <https://github.com/nextstrain/cli/issues/245>.

