### PR TITLE
standalone-installer-unix: Error if Rosetta 2 is not enabled on arm64 Macs

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -115,6 +115,7 @@ target-triple() {
 
         Darwin)
             [[ "$machine" == x86_64 || "$machine" == arm64 ]] || die "unsupported architecture: $machine"
+            [[ "$machine" != arm64 ]] || pgrep -qf /usr/libexec/rosetta/oahd || die "Rosetta 2 not enabled.  Please run:"$'\n\n'"    softwareupdate --install-rosetta"$'\n\n'"and then retry this installation of Nextstrain CLI."
             machine=x86_64
             vendor=apple
             os=darwin


### PR DESCRIPTION
Rosetta 2 is required for both Nextstrain CLI (which doesn't yet have arm64 binaries) and our runtimes.

While we expect most Nextstrain users on arm64 Macs will already have Rosetta 2 enabled, it's good to check and provide a way forward instead of erroring during our installation check about a "Bad CPU type in executable".  In particular, anyone who's setting up a new Mac and installing Nextstrain as one of their first activities is likely to encounter the issue.

If necessary, this check can be bypassed by manually specifying

    TARGET=x86_64-apple-darwin

when running the installer.  This provides an escape hatch we can immediately provide to users should our `pgrep` check turn bad due to changes in Rosetta or macOS.

Related-to: <https://github.com/nextstrain/docs.nextstrain.org/pull/147>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Works on an arm64 Mac with Rosetta enabled
- [ ] Works on an arm64 Mac with Rosetta disabled (maybe hard to test…)
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
