### PR TITLE
Singularity runtime

### DIFF
--- a/.github/actions/run-integration-tests/action.yaml
+++ b/.github/actions/run-integration-tests/action.yaml
@@ -23,6 +23,10 @@ runs:
       shell: bash -l -eo pipefail {0}
       run: nextstrain setup conda
 
+    - if: runner.os != 'macOS' && runner.os != 'Windows'
+      shell: bash -l -eo pipefail {0}
+      run: nextstrain setup singularity
+
     - shell: bash -l -eo pipefail {0}
       run: nextstrain check-setup --set-default
 
@@ -42,6 +46,13 @@ runs:
       run: |
         git -C zika-tutorial clean -dfqx
         nextstrain build --conda --cpus 2 zika-tutorial
+
+    - if: runner.os != 'macOS' && runner.os != 'Windows'
+      name: Build zika-tutorial with --singularity
+      shell: bash -l -eo pipefail {0}
+      run: |
+        git -C zika-tutorial clean -dfqx
+        nextstrain build --singularity --cpus 2 zika-tutorial
 
     - if: runner.os != 'Windows'
       name: Build zika-tutorial with --ambient

--- a/.github/actions/setup-integration-tests/action.yaml
+++ b/.github/actions/setup-integration-tests/action.yaml
@@ -68,6 +68,34 @@ runs:
         python3 --version | grep -F 'Python ${{ inputs.python-version }}.'
         [[ "$(python --version)" == "$(python3 --version)" ]]
 
+    # Install Singularity on Linux.
+    #
+    # We don't install it with Conda because Conda Forge provides a non-suid
+    # build of Singularity.  We're compatible with Singularity's non-suid mode,
+    # but production usages of Singularity are likely to use its suid mode, so
+    # I'd rather test against that.
+    #   -trs, 6 Jan 2023
+    - if: runner.os == 'Linux'
+      shell: bash -l -eo pipefail {0}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # Work in a temp dir to avoid cluttering the caller's working dir
+        pushd "$(mktemp -d)"
+        export "$(grep UBUNTU_CODENAME /etc/os-release)"
+
+        # Download latest SingularityCE .deb for this version of Ubuntu
+        url="$(
+          curl -fsSL --proto '=https' -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/sylabs/singularity/releases/latest \
+              | jq -r '.assets | map(select(.name | endswith("\(env.UBUNTU_CODENAME)_amd64.deb"))) | .[0].browser_download_url')"
+
+        curl -fsSL --proto '=https' "$url" > singularity.deb
+
+        # Install and check that it runs
+        sudo dpkg -i singularity.deb
+        singularity --version
+
     # Clone the small build we'll use as an integration test case.
     - run: git clone https://github.com/nextstrain/zika-tutorial
       shell: bash -l -eo pipefail {0}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,20 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* We've added a new Singularity runtime based on our existing Docker runtime.
+
+  Singularity is a container system freely-available for Linux platforms.  It
+  is commonly available on institutional HPC systems as an alternative to
+  Docker, which is often not supported on such systems.  When you use
+  Singularity with the Nextstrain CLI, you don't need to install any other
+  Nextstrain software dependencies as validated versions are already bundled
+  into a container image by the Nextstrain team.
+
+  Run `nextstrain setup singularity` to get started.
+  ([#248](https://github.com/nextstrain/cli/pull/248))
+
 
 # 6.0.3 (17 January 2023)
 

--- a/doc/aws-batch.md
+++ b/doc/aws-batch.md
@@ -19,13 +19,13 @@ Batch job, monitors the job status, streams the job logs to your terminal, and
 downloads build results back to the `zika-tutorial/` directory.
 
 The interface aims to be very similar to that of local builds (run in the
-Docker, Conda, or ambient runtimes), so the `nextstrain build` command stays in
-the foreground and result files are written back directly to the local build
-directory.  Alternatively, you can specify the `--detach` option to run AWS
-Batch builds in the background once they're submitted.  The Nextstrain CLI will
-tell you how to reattach to the build later to view the logs and download the
-results.  If you forget to use the `--detach` option, you can press Control-Z
-to detach at any point once the build is submitted.
+Docker, Conda, Singularity, or ambient runtimes), so the `nextstrain build`
+command stays in the foreground and result files are written back directly to
+the local build directory.  Alternatively, you can specify the `--detach`
+option to run AWS Batch builds in the background once they're submitted.  The
+Nextstrain CLI will tell you how to reattach to the build later to view the
+logs and download the results.  If you forget to use the `--detach` option, you
+can press Control-Z to detach at any point once the build is submitted.
 
 [AWS Batch]: https://aws.amazon.com/batch/
 [`zika-tutorial/` directory]: https://github.com/nextstrain/zika-tutorial

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -116,7 +116,8 @@ Runtimes
 The Nextstrain CLI provides a consistent interface and computing environment
 for running and visualizing Nextstrain pathogen builds across several different
 computing platforms, such as `Docker <https://docker.com>`__, `Conda
-<https://docs.conda.io/en/latest/miniconda.html>`__, and `AWS Batch
+<https://docs.conda.io/en/latest/miniconda.html>`__,
+:ref:`Singularity <installation/singularity>`, and `AWS Batch
 <https://aws.amazon.com/batch/>`__.
 
 We call the provided computing environments the :term:`Nextstrain runtimes
@@ -131,8 +132,9 @@ At least one of these runtimes must be setup in order for many of
 The default runtime is Docker, using the `nextstrain/base`_ container image.
 Containers provide a tremendous amount of benefit for scientific workflows by
 isolating dependencies and increasing reproducibility. However, they're not
-always appropriate, so a Conda runtime and "ambient" runtime are also supported.
-The installation and setup of supported runtimes is described below.
+always appropriate, so a Conda runtime, Singularity runtime, and "ambient"
+runtime are also supported.  The installation and setup of supported runtimes
+is described below.
 
 .. _nextstrain/base: https://github.com/nextstrain/docker-base
 
@@ -172,6 +174,34 @@ On macOS and Linux, run ``nextstrain setup conda`` to get started.
 This runtime is not directly supported on Windows, but you can use `WSL2
 <https://docs.microsoft.com/en-us/windows/wsl/wsl2-index>`__ to "switch" to
 Linux and run the above setup command.
+
+.. _installation/singularity:
+
+Singularity
+-----------
+
+Singularity is a container system freely-available for Linux platforms.  It is
+commonly available on institutional HPC systems as an alternative to Docker,
+which is often not supported on such systems.  When you use Singularity with
+the Nextstrain CLI, you don't need to install any other Nextstrain software
+dependencies as validated versions are already bundled into a container image
+by the Nextstrain team.
+
+Run ``nextstrain setup singularity`` to get started.
+
+Note that the Singularity project forked into two separate projects in late
+2021: `SingularityCE`_ under `Sylabs`_ and `Apptainer`_ under the `Linux
+Foundation`_.  Either fork should work with Nextstrain CLI, as both projects
+still provide very similar interfaces and functionality via the ``singularity``
+command.  You can read `Sylab's announcement`_ and `Apptainer's announcement`_
+for more information on the fork.
+
+.. _SingularityCE: https://sylabs.io/singularity/
+.. _Sylabs: https://sylabs.io/
+.. _Apptainer: https://apptainer.org
+.. _Linux Foundation: https://www.linuxfoundation.org/
+.. _Sylab's announcement: https://sylabs.io/2022/06/singularityce-is-singularity/
+.. _Apptainer's announcement: https://apptainer.org/news/community-announcement-20211130
 
 Ambient
 -------
@@ -238,6 +268,10 @@ based on what's available. You should see output similar to the following:
    ✔ yes: augur is installed and runnable
    ✔ yes: auspice is installed and runnable
 
+   # singularity is supported
+   ✔ yes: singularity is installed
+   ✔ yes: singularity works
+
    # ambient is not supported
    ✔ yes: snakemake is installed and runnable
    ✘ no: augur is installed and runnable
@@ -248,15 +282,16 @@ based on what's available. You should see output similar to the following:
    ✘ no: job queue "nextstrain-job-queue" exists
    ✘ no: S3 bucket "nextstrain-jobs" exists
 
-   All good!  Supported Nextstrain runtimes: docker, conda
+   All good!  Supported Nextstrain runtimes: docker, conda, singularity
 
    Setting default runtime to docker.
 
 If the output doesn't say "All good!" and list at least one supported
-Nextstrain runtime (typically Docker, Conda, or ambient), then something may be
-wrong with your installation.
+Nextstrain runtime (typically Docker, Conda, Singularity, or ambient), then
+something may be wrong with your installation.
 
 The default is written to the :file:`~/.nextstrain/config` file. If multiple
 runtimes are supported, you can override the default for specific runs
-using command-line options such as ``--docker``, ``--conda``, ``--ambient``,
-and ``--aws-batch``, e.g. ``nextstrain build --ambient …``.
+using command-line options such as ``--docker``, ``--conda``,
+``--singularity``, ``--ambient``, and ``--aws-batch``, e.g. ``nextstrain build
+--ambient …``.

--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -178,12 +178,12 @@ def runner_module_argument(name: str) -> RunnerModule:
     >>> runner_module_argument("invalid")
     Traceback (most recent call last):
         ...
-    argparse.ArgumentTypeError: invalid runtime name: 'invalid'; valid names are: 'docker', 'conda', 'ambient', 'aws-batch'
+    argparse.ArgumentTypeError: invalid runtime name: 'invalid'; valid names are: 'docker', 'conda', 'singularity', 'ambient', 'aws-batch'
 
     >>> runner_module_argument("Invalid Name")
     Traceback (most recent call last):
         ...
-    argparse.ArgumentTypeError: invalid runtime name: 'Invalid Name' (normalized to 'invalid-name'); valid names are: 'docker', 'conda', 'ambient', 'aws-batch'
+    argparse.ArgumentTypeError: invalid runtime name: 'Invalid Name' (normalized to 'invalid-name'); valid names are: 'docker', 'conda', 'singularity', 'ambient', 'aws-batch'
     """
     try:
         return runner_module(name)

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -1,7 +1,7 @@
 """
 Checks for supported runtimes.
 
-Four runtimes are tested by default:
+Five runtimes are tested by default:
 
   • Our Docker image is the preferred runtime.  Docker itself must
     be installed and configured on your computer first, but once it is, the
@@ -11,6 +11,12 @@ Four runtimes are tested by default:
     completeness. This runtime is more isolated and reproducible than your
     ambient runtime, but is less isolated and robust than the Docker
     runtime.
+
+  • Our Singularity runtime uses the same container image as our Docker
+    runtime.  Singularity must be installed and configured on your computer
+    first, although it is often already present on HPC systems.  This runtime
+    is more isolated and reproducible than the Conda runtime, but potentially
+    less so than the Docker runtime.
 
   • Your ambient setup will be tested for snakemake, augur, and auspice.
     Their presence implies a working runtime, but does not guarantee

--- a/nextstrain/cli/command/update.py
+++ b/nextstrain/cli/command/update.py
@@ -5,8 +5,8 @@ The default runtime ({default_runner_name}) is updated when this command is run
 without arguments.  Provide a runtime name as an argument to update a specific
 runtime instead.
 
-Only two runtimes currently support updates: Docker and Conda.  Both may take
-several minutes as new software versions are downloaded.
+Three runtimes currently support updates: Docker, Conda, and Singularity.
+Updates may take several minutes as new software versions are downloaded.
 
 This command also checks for newer versions of the Nextstrain CLI (the
 ``nextstrain`` program) itself and will suggest upgrade instructions if an

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -55,7 +55,7 @@ from time import sleep
 from typing import Iterable, NamedTuple, Tuple, Union
 from .. import runner
 from ..argparse import add_extended_help_flags, SUPPRESS, SKIP_AUTO_DEFAULT_IN_HELP
-from ..runner import docker, ambient, conda
+from ..runner import docker, ambient, conda, singularity
 from ..util import colored, remove_suffix, warn
 from ..volume import NamedVolume
 
@@ -136,7 +136,7 @@ def register_parser(subparser):
     runner.register_runners(
         parser,
         exec    = ["auspice", "view", "--verbose", "--datasetDir=.", "--narrativeDir=."],
-        runners = [docker, ambient, conda])
+        runners = [docker, ambient, conda, singularity])
 
     return parser
 
@@ -176,7 +176,7 @@ def run(opts):
 
     # A volume which will be our working dir.
     working_volume = NamedVolume("auspice/data", data_dir)
-    opts.volumes.append(working_volume) # for Docker
+    opts.volumes.append(working_volume) # for Docker and Singularity
 
     # If auspice/ exists, then use it for datasets.  Otherwise, look for
     # datasets in the given dir.

--- a/nextstrain/cli/runner/singularity.py
+++ b/nextstrain/cli/runner/singularity.py
@@ -1,0 +1,372 @@
+"""
+Run commands inside a container image using Singularity.
+
+Uses the images built for the Docker runtime by automatically converting them
+to local Singularity images.  Local images are stored as files named
+:file:`~/.nextstrain/runtimes/singularity/images/{repository}/{tag}.sif`.
+"""
+
+import itertools
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable, List
+from urllib.parse import urlsplit
+from .. import config, hostenv
+from ..errors import UserError
+from ..paths import RUNTIMES
+from ..types import RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
+from ..util import capture_output, colored, exec_or_return, split_image_name, warn
+from . import docker
+
+flatten = itertools.chain.from_iterable
+
+
+RUNTIME_ROOT = RUNTIMES / "singularity/"
+
+IMAGES = RUNTIME_ROOT / "images/"
+
+CACHE = RUNTIME_ROOT / "cache/"
+
+
+# The default intentionally omits an explicit "latest" tag so that on the first
+# `nextstrain update` it gets pinned in the config file to the most recent
+# "build-*" tag.  Users can set an explicit "latest" tag in config to always
+# use the most recent image and not pin to "build-*" tags.
+#   (copied from ./docker.py on 5 Jan 2022)
+DEFAULT_IMAGE = os.environ.get("NEXTSTRAIN_SINGULARITY_IMAGE") \
+             or config.get("singularity", "image") \
+             or "docker://nextstrain/base"
+
+
+SINGULARITY_CONFIG_ENV = {
+    # Store image caches in our runtime root instead of ~/.singularity/…
+    "SINGULARITY_CACHEDIR": str(CACHE),
+}
+
+SINGULARITY_EXEC_ARGS = [
+    # Increase isolation
+    "--contain",
+    "--no-home",
+    "--cleanenv",
+
+    # Since we use --no-home above, avoid warnings about not being able to cd
+    # to $HOME (the default behaviour).  run() will override this by specifying
+    # --pwd again.
+    "--pwd", "/",
+]
+
+
+def register_arguments(parser) -> None:
+    """
+    No-op.  No arguments necessary.
+    """
+    pass
+
+
+def run(opts, argv, working_volume = None, extra_env = {}, cpus: int = None, memory: int = None) -> int:
+    docker.assert_volumes_exist(opts.volumes)
+
+    # We require docker:// qualified image names in this runtime internally,
+    # but the external --image option is common to a few runtimes and takes
+    # unqualified names.
+    #
+    # XXX TODO: We could probably support other schemes Singularity supports…
+    # but it's likely not worth it until we have a need (if ever).
+    #   -trs, 5 Jan 2023
+    image = f"docker://{opts.image}" if not opts.image.startswith("docker://") else opts.image
+
+    if not image_exists(image):
+        if not download_image(image):
+            raise UserError(f"Unable to create local Singularity image for {image!r}.")
+
+    # XXX TODO: In the future we might want to set rlimits based on cpus and
+    # memory, at least on POSIX systems.
+    #   -trs, 21 May 2020 (copied from ./native.py on 30 Aug 2022)
+
+    extra_env = {
+        **SINGULARITY_CONFIG_ENV,
+
+        # Pass environment into the container via Singularity's bespoke
+        # prefixing with SINGULARITYENV_….¹
+        #
+        # ¹ <https://docs.sylabs.io/guides/3.0/user-guide/environment_and_metadata.html#environment>
+        #
+        # Pass through certain environment variables
+        **{f"SINGULARITYENV_{k}": os.environ[k]
+            for k in hostenv.forwarded_names
+             if k in os.environ},
+
+        # Plus any extra environment variables provided by us
+        **{f"SINGULARITYENV_{k}": v
+            for k, v in extra_env.items()},
+    }
+
+    return exec_or_return([
+        "singularity", "run", *SINGULARITY_EXEC_ARGS,
+
+        # Map directories to bind mount into the container.
+        *flatten(("--bind", "%s:%s:%s" % (v.src.resolve(strict = True), docker.mount_point(v), "rw" if v.writable else "ro"))
+            for v in opts.volumes
+             if v.src is not None),
+
+        # Change the default working directory if requested
+        *(("--pwd", "/nextstrain/%s" % working_volume.name) if working_volume else ()),
+
+        str(image_path(image)),
+        *argv,
+    ], extra_env)
+
+
+def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus:
+    if not setup_image(dry_run, force):
+        return False
+
+    return True
+
+
+def setup_image(dry_run: bool = False, force: bool = False) -> bool:
+    """
+    Create Singularity image if it's not already available locally.
+
+    Though not strictly required, by doing this during setup we avoid the
+    initial download and creation on first use instead.
+    """
+    image = DEFAULT_IMAGE
+    path = image_path(image)
+    exists = path.exists()
+
+    if not force and exists:
+        print(f"Using existing local copy of Singularity image {image}.")
+        print(f"  Hint: if you want to ignore this existing local copy, re-run `nextstrain setup` with --force.")
+        return True
+
+    if exists:
+        print(f"Removing existing local copy of Singularity image {image}…")
+        if not dry_run:
+            path.unlink()
+
+    update_ok = _update(dry_run)
+
+    if not update_ok:
+        return False
+
+    return True
+
+
+def test_setup() -> RunnerTestResults:
+    def test_run():
+        try:
+            capture_output([
+                "singularity", "exec", *SINGULARITY_EXEC_ARGS,
+
+                # XXX TODO: We should test --bind, as that's maybe most likely
+                # to be adminstratively disabled, but it's a bit more ceremony
+                # to arrange for a reliable dir to bind into the container.
+                # Putting it off for now…
+                #   -trs, 5 Jan 2023
+
+                # Use the official Busybox image, which is tiny, because
+                # the hello-world image doesn't have /bin/sh, which
+                # Singularity requires.
+                "docker://busybox",
+
+                "/bin/true"
+                ], extra_env = SINGULARITY_CONFIG_ENV)
+        except:
+            return False
+        else:
+            return True
+
+    return [
+        ("singularity is installed",
+            shutil.which("singularity") is not None),
+        ("singularity works",
+            test_run()),
+    ]
+
+
+def set_default_config() -> None:
+    """
+    Sets ``singularity.image``, if it isn't already set, to the latest
+    ``build-*`` image.
+    """
+    config.setdefault("singularity", "image", latest_build_image(DEFAULT_IMAGE))
+
+
+def update() -> RunnerUpdateStatus:
+    """
+    Download and convert the latest Docker runtime image into a local
+    Singularity image.
+
+    Prunes old local Singularity image versions.
+    """
+    return _update()
+
+
+def _update(dry_run: bool = False) -> RunnerUpdateStatus:
+    current_image = DEFAULT_IMAGE
+    latest_image  = latest_build_image(current_image)
+
+    if latest_image == current_image:
+        print(colored("bold", "Updating Singularity image %s…" % current_image))
+    else:
+        print(colored("bold", "Updating Singularity image from %s to %s…" % (current_image, latest_image)))
+    print()
+
+    # Pull the latest image down
+    if not dry_run:
+        if not download_image(latest_image):
+            return False
+
+        # Update the config file to point to the new image so we use it by
+        # default going forward.
+        config.set("singularity", "image", latest_image)
+
+    # Prune any old images to avoid leaving lots of hidden disk use around.
+    print()
+    print(colored("bold", "Pruning old images…"))
+    print()
+
+    if not dry_run:
+        try:
+            for old_image in old_build_images(latest_image):
+                print(f"Deleting {old_image}")
+                old_image.unlink()
+        except OSError as error:
+            warn()
+            warn("Update succeeded, but an error occurred pruning old image versions:")
+            warn("  ", error)
+            warn()
+            warn("Not to worry, we'll try again the next time you run `nextstrain update`.")
+            warn()
+
+    return True
+
+
+def download_image(image: str = DEFAULT_IMAGE) -> bool:
+    """
+    Download and convert a remote Singularity ``docker://` *image* into a local
+    Singularity image using ``singularity build``.
+    """
+    # We can avoid downloading/conversion for build-* tags (which are static)
+    # if the image already exists locally.
+    _, tag = split_image_name(docker_image_name(image))
+
+    if docker.is_build_tag(tag) and image_exists(image):
+        print(f"Singularity image {image} exists and is up-to-date.")
+        return True
+
+    # …but otherwise we must create it fresh.
+    path = image_path(image)
+    path.parent.mkdir(exist_ok = True, parents = True)
+
+    env = {
+        **os.environ.copy(),
+        **SINGULARITY_CONFIG_ENV,
+    }
+
+    try:
+        subprocess.run(
+            ["singularity", "build", path, image],
+            env   = env,
+            check = True)
+    except (OSError, subprocess.CalledProcessError):
+        return False
+
+    return True
+
+
+def old_build_images(image: str) -> List[Path]:
+    """
+    Return a list of local Singularity image paths which were derived from an
+    older version of *image* tagged with "build-*".
+
+    If *image* isn't tagged "build-*", nothing is returned out of an abundance
+    of caution.  Our "build-*" timestamps use an ISO-8601 timestamp, so oldness
+    is determined by sorting lexically.
+    """
+    repository, tag = split_image_name(docker_image_name(image))
+
+    if not docker.is_build_tag(tag):
+        return []
+
+    # List all local images from the same respository, e.g. nextstrain/base.
+    images = (IMAGES / repository).glob("*.sif")
+
+    # Return the paths of images with build tags that come before our current
+    # build tag, as well as the image with the "latest" tag.  The latter is
+    # useful to include because it will likely be out of date when the current
+    # tag is a build tag (guaranteed above).
+    return [
+        path
+            for path in images
+             if (docker.is_build_tag(path.stem) and path.stem < tag)
+             or path.stem == "latest"
+    ]
+
+
+def image_exists(image: str = DEFAULT_IMAGE) -> bool:
+    """
+    Check if a Singularity ``docker://`` *image* exists locally, returning True
+    or False.
+    """
+    return image_path(image).exists()
+
+
+def image_path(image: str = DEFAULT_IMAGE) -> Path:
+    """
+    Return a local path to use for a Singularity ``docker://`` *image*.
+    """
+    repository, tag = split_image_name(docker_image_name(image))
+    return IMAGES / repository / f"{tag}.sif"
+
+
+def latest_build_image(image: str = DEFAULT_IMAGE) -> str:
+    return "docker://" + docker.latest_build_image(docker_image_name(image))
+
+
+def docker_image_name(image: str = DEFAULT_IMAGE) -> str:
+    """
+    Convert a Singularity ``docker://`` *image* into a Docker image name.
+
+    >>> docker_image_name("docker://nextstrain/base:latest")
+    'nextstrain/base:latest'
+
+    >>> docker_image_name("nextstrain/base")
+    Traceback (most recent call last):
+        ...
+    cli.errors.UserError: Error: Singularity runtime currently only supports docker:// images but got: 'nextstrain/base'
+    """
+    url = urlsplit(image)
+
+    if url.scheme != "docker":
+        raise UserError(f"Singularity runtime currently only supports docker:// images but got: {image!r}")
+
+    return url.netloc + url.path
+
+
+def versions() -> Iterable[str]:
+    if not image_exists():
+        yield f"{DEFAULT_IMAGE} (not present)"
+        return
+
+    yield f"{DEFAULT_IMAGE} ({image_path()})"
+
+    try:
+        yield from run_bash(docker.report_component_versions())
+    except (OSError, subprocess.CalledProcessError):
+        pass
+
+
+def run_bash(script: str, image: str = DEFAULT_IMAGE) -> List[str]:
+    """
+    Run a Bash *script* inside of the container *image*.
+
+    Returns the output of the script as a list of strings.
+    """
+    return capture_output([
+        "singularity", "run", *SINGULARITY_EXEC_ARGS, image_path(image),
+            "bash", "-c", script
+    ])

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -366,12 +366,12 @@ def runner_module(name: str) -> RunnerModule:
     >>> runner_module("invalid")
     Traceback (most recent call last):
         ...
-    ValueError: invalid runtime name: 'invalid'; valid names are: 'docker', 'conda', 'ambient', 'aws-batch'
+    ValueError: invalid runtime name: 'invalid'; valid names are: 'docker', 'conda', 'singularity', 'ambient', 'aws-batch'
 
     >>> runner_module("Invalid Name")
     Traceback (most recent call last):
         ...
-    ValueError: invalid runtime name: 'Invalid Name' (normalized to 'invalid-name'); valid names are: 'docker', 'conda', 'ambient', 'aws-batch'
+    ValueError: invalid runtime name: 'Invalid Name' (normalized to 'invalid-name'); valid names are: 'docker', 'conda', 'singularity', 'ambient', 'aws-batch'
     """
     # Import here to avoid circular import
     from .runner import all_runners_by_name


### PR DESCRIPTION
Add a new runner for a Singularity runtime based on the Docker runtime

It's been my intention to support Singularity since day 1, but I never got around to implementing it because usage seemed little to non-existent amongst Nextstrain users I knew about.  (Though maybe that's a chicken-or-the-egg problem!)  We've since had users report their ad-hoc use of Singularity with Nextstrain, however, and Singularity is often the only containerization method supported by HPC systems.  So it seems important to support.

Resolves <https://github.com/nextstrain/cli/issues/2>.

### Testing

You can test this yourself using a source checkout of this PR, or with the standalone build produced by this PR:

```
curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux \
    | DESTINATION=/tmp/cli-test bash -s pr-build/248
```

(Download will be much slower than a normal release, but that's ok for dev.)

No need to run the two final commands the installer suggests at the end.

Then get started testing it with:

```
/tmp/cli-test/nextstrain setup singularity
```

### Checks

- [x] `check-setup` works
- [x] `setup` works
- [x] `update` works
- [x] `build` works
- [x] `view` works
- [x] `shell` works
- [x] Tests pass locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
