### PR TITLE
standalone-installer-unix: Check for Rosetta 2 in a way that works on macOS 11 too

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -115,7 +115,7 @@ target-triple() {
 
         Darwin)
             [[ "$machine" == x86_64 || "$machine" == arm64 ]] || die "unsupported architecture: $machine"
-            [[ "$machine" != arm64 ]] || pgrep -qf /usr/libexec/rosetta/oahd || die "Rosetta 2 not enabled.  Please run:"$'\n\n'"    softwareupdate --install-rosetta"$'\n\n'"and then retry this installation of Nextstrain CLI."
+            [[ "$machine" != arm64 ]] || pgrep -qU _oahd 2>/dev/null || die "Rosetta 2 not enabled.  Please run:"$'\n\n'"    softwareupdate --install-rosetta"$'\n\n'"and then retry this installation of Nextstrain CLI."
             machine=x86_64
             vendor=apple
             os=darwin


### PR DESCRIPTION
The previous check worked only on macOS 12 and 13, because the executable path on macOS 11 is:

    /Library/Apple/usr/libexec/oah/oahd

On all macOS versions, however, the process runs as the _oahd user.  In case the _oahd user doesn't exist, direct stderr to the bit bucket to avoid a noisy error being confusing to the person running the installer.

Troubleshooting happened on Slack¹ with the help of @cassiawag and @corneliusroemer.

¹ <https://bedfordlab.slack.com/archives/C0K3GS3J8/p1675714639052449>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
