### PR TITLE
dev: Pin types-requests on Python 3.6 to a version that works with mypy on 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,8 @@ setup(
             "sphinx_rtd_theme",
             "types-docutils",
             "types-setuptools",
-            "types-requests",
+            "types-requests; python_version != '3.6'",
+            "types-requests <=2.28.11.12; python_version == '3.6'",
         ],
     },
 )


### PR DESCRIPTION
mypy 0.971 is the last version to support Python 3.6, so this is what pip installs on 3.6.

types-requests 2.28.11.12 is the last version to support mypy <1.0.0, due to changes in how the "Self" type is handled.¹  However, there's no way to declare that in package metadata (without requiring mypy, which is inappropriate for a typeshed package), so we have to resolve this dependency ourselves.²

With a too-new types-requests, mypy fails on 3.6 with errors like:

    nextstrain/cli/remote/nextstrain_dot_org.py:230: error: Self? has no attribute "auth"

which we saw in CI failures.³

We'll drop support for Python 3.6 sooner than later, but for now, keep it going.

¹ <https://github.com/python/typeshed/commit/7180d0223b3cfb0275bdc4dff902439536dd4e3d>
  <https://github.com/python/typeshed/pull/9702>

² It would be possible if, for example, Python package metadata
  supported a "Conflicts" field, as many packaging systems do.

³ <https://github.com/nextstrain/cli/actions/runs/4266385449/jobs/7426841852#step:5:78>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
