### PR TITLE
dev: Run CI every day on a schedule to catch external breaking changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+  # Routinely check that we continue to work in the face of external changes.
+  schedule:
+    # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * *"
+
 jobs:
   test-source:
     name: test-source (python=${{ matrix.python }} os=${{ matrix.os }})


### PR DESCRIPTION
Changes to external dependencies, like new releases of Python packages, are a common source of build breakage.¹  Ensure we know sooner than later when they break our build by running CI every day.

¹ The latest example is <https://github.com/nextstrain/cli/pull/257>.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
