### PR TITLE
argparse: Restore --help and --help-all difference on Python ≥3.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,14 @@ development source code and as such may not be routinely kept up to date.
   `{files}`.
   ([#260](https://github.com/nextstrain/cli/pull/260))
 
+* When running on Python ≥3.10, the `--help` output of `nextstrain build`,
+  `nextstrain view`, and `nextstrain shell` once again shows just the most
+  common options.  All options are still shown with `--help-all`.  A regression
+  since Python 3.10 meant that `--help` acted the same as `--help-all` before
+  this fix.  This affected any installation on Python ≥3.10, including
+  standalone installations, since the standalone binaries bundle Python 3.10.
+  ([#259](https://github.com/nextstrain/cli/pull/259))
+
 
 # 6.1.0.post1 (18 January 2023)
 

--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -1,6 +1,7 @@
 """
 Custom helpers for extending the behaviour of argparse standard library.
 """
+import sys
 from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentTypeError, SUPPRESS
 from itertools import takewhile
 from textwrap import indent
@@ -113,9 +114,13 @@ class ShowBriefHelp(Action):
 
     def truncate_help(self, full_help):
         """
-        Truncate the full help after the standard "optional arguments" listing
-        and before any custom argument groups.
+        Truncate the full help after the standard "options" (or "optional
+        arguments") listing and before any custom argument groups.
         """
+        # See <https://github.com/python/cpython/pull/23858>
+        # and <https://bugs.python.org/issue9694>.
+        heading = "options:\n" if sys.version_info >= (3, 10) else "optional arguments:\n"
+
         seen_optional_arguments_heading = False
 
         def before_extra_argument_groups(line):
@@ -127,7 +132,7 @@ class ShowBriefHelp(Action):
             nonlocal seen_optional_arguments_heading
 
             if not seen_optional_arguments_heading:
-                if line == "optional arguments:\n":
+                if line == heading:
                     seen_optional_arguments_heading = True
 
             return not seen_optional_arguments_heading \


### PR DESCRIPTION
The section heading used in argparse's formatted help output changed in 3.10¹, rendering --help equivalent to --help-all.  This affected anyone with Nextstrain CLI installed on Python 3.10 or newer, including our standalone installation binaries.

¹ <https://github.com/python/cpython/pull/23858>
  <https://bugs.python.org/issue9694>
### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->
- [x] Broken functionality on local dev env is fixed by this
- [x] Standalone build produced by CI is fixed by this
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
