### PR TITLE
remote.nextstrain_dot_org: Fix uninterpolated placeholder in error message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,14 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* An error message that's printed by `nextstrain remote upload` when unknown
+  files are given for upload to destinations on nextstrain.org now properly
+  includes the actual list of unknown files instead of the placeholder
+  `{files}`.
+  ([#260](https://github.com/nextstrain/cli/pull/260))
+
 
 # 6.1.0.post1 (18 January 2023)
 

--- a/nextstrain/cli/remote/nextstrain_dot_org.py
+++ b/nextstrain/cli/remote/nextstrain_dot_org.py
@@ -196,7 +196,7 @@ def upload(url: urllib.parse.ParseResult, local_files: List[Path], dry_run: bool
         # appropriate API requests to the group endpoint (which doesn't yet
         # exist).
         #   -trs, 23 Sept 2021
-        raise UserError("""
+        raise UserError(f"""
             Only datasets (v2) and narratives are currently supported for
             upload to nextstrain.org, but other files were given:
 


### PR DESCRIPTION
When an unknown file was given for upload, the error message incorrectly included the literal string "{files}" instead of replacing it with the actual list of files.

Although this string doesn't need to be an f-string, the other similar error messages below it do, and preserving the parallel construction of the error messages is helpful for readability.

### Context

https://support.nextstrain.org/agent/nextstrain/nextstrain/tickets/details/668036000003639001

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Correct behaviour after fix locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
