### PR TITLE
standalone-installer-unix: Use `eval` instead of `source` to avoid issues on old versions of Bash

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -72,7 +72,7 @@ main() {
     log "Checking installation"
     local installed_version
     if ! installed_version="$("$DESTINATION"/nextstrain --version)"; then
-        die "installation check failed: unable to run \`"$DESTINATION"/nextstrain --version\`; look for error message above."
+        die "installation check failed: unable to run \`\"$DESTINATION\"/nextstrain --version\`; look for error message above."
     fi
 
     cat <<~~

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -91,8 +91,8 @@ Nextstrain CLI ($installed_version) installed to $DESTINATION.
 To make the "nextstrain" command available in your default shell ($shell)
 without using the full path, please run these two commands now:
 
-    echo 'source <("$DESTINATION/nextstrain" init-shell $shell)' >> $rc
-    source <("$DESTINATION/nextstrain" init-shell $shell)
+    echo 'eval "$("$DESTINATION/nextstrain" init-shell $shell)"' >> $rc
+    eval "$("$DESTINATION/nextstrain" init-shell $shell)"
 
 The first adds a line to your shell initialization file ($rc) for future
 sessions.  The second sets up your current shell session.  You only need to run

--- a/nextstrain/cli/command/init_shell.py
+++ b/nextstrain/cli/command/init_shell.py
@@ -6,7 +6,7 @@ If PATH does not contain the expected installation path, emits an appropriate
 
 Use this command in your shell config with a line like the following::
 
-    source <({INSTALLATION_PATH}/nextstrain init-shell)
+    eval "$({INSTALLATION_PATH}/nextstrain init-shell)"
 
 Exits with error if run in an non-standalone installation.
 """
@@ -53,6 +53,19 @@ def register_parser(subparser):
 
 
 def run(opts):
+    # The output of this command must remain less than the limits on command
+    # line length.  These vary by OS but also system to system.
+    #
+    # execve() is typically limited on the total argv + environ size to
+    # `getconf ARG_MAX`, but there are also limits on the size of a single
+    # argument within that total.  This single argument limit applies to the
+    # `eval "$(…)"` pattern we recommend.  On Linux, for example, the limit is
+    # hardcoded to 131071 bytes (MAX_ARG_STRLEN constant).
+    #
+    # The `source <(…)` pattern doesn't suffer this limitation but has other
+    # issues on the old Bash version found on macOS.
+    #   -trs, 7 March 2023
+
     if not INSTALLATION_PATH:
         raise UserError("No shell init required because this is not a standalone installation.")
 


### PR DESCRIPTION
In Bash prior to 4.0 (released in 2009), the `source` builtin does not properly read input from a pipe, named or otherwise.  When given a pipe, such as via process substitution (i.e. `<(…)`), it silently does nothing and exits 0.  This can cause a SIGPIPE in the process on other end of the pipe and, in Python, a BrokenPipeError.

Unfortunately, macOS ships with Bash 3.2.57 (released in 2007) and, for legal reasons, is unlikely to ever be upgraded.  Switching to `eval` with command substitution (i.e. `$(…)`) avoids the issue for Bash users on macOS and results in no functional change for everyone else.

We _will_ have to ensure that the output of `nextstrain init-shell` remains below command line length limits since the output is now interpolated into the command line, but I don't think this will ever be an issue since the initialization sequence should remain pretty short.

Initial problem report and troubleshooting with @alliblk and @victorlin happened in Slack.¹

¹ <https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1677871789858519>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested locally in my bashrc and interactively
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
