### PR TITLE
dev: Stop using Ubuntu 18.04 in CI; it will soon be dropped by GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,10 @@ jobs:
         # considerations affecting the choice of build machine OS¹ and future
         # plans for robust, turnkey build environments².
         #
+        # On Linux, we build inside a container to avoid portability issues, so
+        # the container's host OS version here doesn't have an impact (other
+        # than CI stability).
+        #
         # ¹ https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_distributing_binary_portability.html
         # ² https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_status.html#an-official-build-environment
         #
@@ -107,7 +111,7 @@ jobs:
         # Mac Mini for ~$700 which would pay for itself in less than 2 months.
         #   -trs, 31 May 2022
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             exe: nextstrain
 
@@ -257,7 +261,6 @@ jobs:
         #
         # XXX TODO: macOS aarch64 (M1, Apple Silicon, arm64); see above.
         include:
-          - { os: ubuntu-18.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           - { os: macos-11,     target: x86_64-apple-darwin }

--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
           - macos-11


### PR DESCRIPTION
Ubuntu 18.04 was to be dropped by GitHub on 1 Dec 2022, but they later extended that to April 2023.¹  That's in a few weeks and I've already noticed the brownouts, so time to get moving.

Building on 18.04 doesn't matter anymore thanks to the containerized build environment using manylinux images, but it'd still be nice to test on older versions.  We could use containers for this too, but doing so is an exercise for the future.

¹ <https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
