### PR TITLE
Add newline before eval command

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -92,7 +92,7 @@ Nextstrain CLI ($installed_version) installed to $DESTINATION.
 To make the "nextstrain" command available in your default shell ($shell)
 without using the full path, please run these two commands now:
 
-    echo 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> $rc
+    printf '\n%s\n' 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> $rc
     eval "\$("$DESTINATION/nextstrain" init-shell $shell)"
 
 The first adds a line to your shell initialization file ($rc) for future


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Previously, the command could result in unexpected errors if the shell init file did not end with a newline (for reasons beyond our control).

If the file already ends with a newline, this comes with the added benefit of using whitespace to distinguish the "scope" of this command as separate from whatever was there before.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

I noticed this because my own `.zshrc` file did not end with a newline and I got this error upon opening new sessions after running the command:

```
/Users/vlin/.zshrc:63: parse error near `\n'
```

which made sense after inspecting the file contents:

```
function some-function()
{
    …
}eval "$("/Users/vlin/.nextstrain/cli-standalone/nextstrain" init-shell zsh)"
```

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Ran `bin/standalone-installer-unix` locally to verify output can be copy-pasted as-is
- [x] Standalone installers checks pass, outputs look good there too
- [x] ~Other checks pass~ failing because of unrelated reasons, but this change should not affect the outcome of those checks

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
