### PR TITLE
standalone-installer-windows: Use call operator (&) instead of Invoke-Expression

### DIFF
--- a/bin/standalone-installer-windows
+++ b/bin/standalone-installer-windows
@@ -108,7 +108,7 @@ function main([string]$version) {
         Remove-Item -Recurse -Force $tmp
     }
 
-    $version = Invoke-Expression "$destination\nextstrain --version"
+    $version = & "$destination\nextstrain" --version
 
     echo @"
 ______________________________________________________________________________


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

It is not uncommon for user home directories to have spaces, and Invoke-Expression [does not work well](https://devblogs.microsoft.com/powershell/invoke-expression-considered-harmful/) with paths that have spaces. The call operator is more suitable for this use case.

Quoting updated to reflect [call operator](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.3#call-operator-) [syntax](https://ss64.com/ps/call.html).

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Fixes #276 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually tested on a Windows VM installing to `C:\Users\test user\`.
- [x] ~Checks pass~ some are failing because of unrelated reasons, but this change should not affect the outcome of those checks

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
