### PR TITLE
Standalone installer parity

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -71,11 +71,11 @@ main() {
         rc="$(shell-rc "$shell")"
 
         # Initialize for this session.
-        eval "$("$DESTINATION/nextstrain" init-shell $shell)"
+        eval "$("$DESTINATION/nextstrain" init-shell "$shell")"
 
         # Automatically initialize for new sessions.
         # shellcheck disable=SC2016
-        printf '\n%s\n' 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> "$rc"
+        printf '\n%s\n' 'eval "\$("$DESTINATION/nextstrain" init-shell "$shell")"' >> "$rc"
     fi
 
     popd >/dev/null

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -87,8 +87,8 @@ main() {
 
     log "Checking installation"
     local installed_version
-    if ! installed_version="$("$DESTINATION"/nextstrain --version)"; then
-        die "installation check failed: unable to run \`\"$DESTINATION\"/nextstrain --version\`; look for error message above."
+    if ! installed_version="$(nextstrain --version)"; then
+        die "installation check failed: unable to run \`nextstrain --version\`; look for error message above."
     fi
 
     cat <<~~

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -63,6 +63,21 @@ main() {
     mkdir -p "$(dirname "$DESTINATION")"
     mv standalone "$DESTINATION"
 
+    if [[ "$(type -p nextstrain 2>/dev/null)" != "$DESTINATION/nextstrain" ]]; then
+        log "Making Nextstrain CLI available for the current user"
+
+        local shell rc
+        shell="$(default-shell)"
+        rc="$(shell-rc "$shell")"
+
+        # Initialize for this session.
+        eval "$("$DESTINATION/nextstrain" init-shell $shell)"
+
+        # Automatically initialize for new sessions.
+        # shellcheck disable=SC2016
+        printf '\n%s\n' 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> "$rc"
+    fi
+
     popd >/dev/null
 
     if ! debug; then
@@ -82,24 +97,6 @@ ______________________________________________________________________________
 Nextstrain CLI ($installed_version) installed to $DESTINATION.
 
 ~~
-
-    if [[ "$(type -p nextstrain 2>/dev/null)" != "$DESTINATION/nextstrain" ]]; then
-        local shell rc
-        shell="$(default-shell)"
-        rc="$(shell-rc "$shell")"
-
-        cat <<~~
-To make the "nextstrain" command available in your default shell ($shell)
-without using the full path, please run these two commands now:
-
-    printf '\n%s\n' 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> $rc
-    eval "\$("$DESTINATION/nextstrain" init-shell $shell)"
-
-The first adds a line to your shell initialization file ($rc) for future
-sessions.  The second sets up your current shell session.  You only need to run
-these once.
-~~
-    fi
 }
 
 target-triple() {
@@ -175,17 +172,17 @@ shell-rc() {
                     #   order, and reads and executes commands from the first one
                     #   that exists and is readable.
                     #
-                    if [[ -r ~/.bash_profile ]]; then
+                    if [[ -r "$HOME/.bash_profile" ]]; then
                         # shellcheck disable=SC2088
-                        echo "~/.bash_profile"
+                        echo "$HOME/.bash_profile"
 
-                    elif [[ -r ~/.bash_login ]]; then
+                    elif [[ -r "$HOME/.bash_login" ]]; then
                         # shellcheck disable=SC2088
-                        echo "~/.bash_login"
+                        echo "$HOME/.bash_login"
 
-                    elif [[ -r ~/.profile ]]; then
+                    elif [[ -r "$HOME/.profile" ]]; then
                         # shellcheck disable=SC2088
-                        echo "~/.profile"
+                        echo "$HOME/.profile"
 
                     else
                         # If none exist, then we fallback to ~/.bash_profile
@@ -193,19 +190,19 @@ shell-rc() {
                         # init commands.
                         #
                         # shellcheck disable=SC2088
-                        echo "~/.bash_profile"
+                        echo "$HOME/.bash_profile"
                     fi;;
                 *)
                     # shellcheck disable=SC2088
-                    echo "~/.bashrc";;
+                    echo "$HOME/.bashrc";;
             esac;;
         zsh)
-            echo "${ZDOTDIR:-~}/.zshrc";;
+            echo "${ZDOTDIR:-$HOME}/.zshrc";;
         *)
             # A decent guess?
             #
             # shellcheck disable=SC2088
-            echo "~/.${shell}rc";;
+            echo "$HOME/.${shell}rc";;
     esac
 }
 

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -92,7 +92,7 @@ Nextstrain CLI ($installed_version) installed to $DESTINATION.
 To make the "nextstrain" command available in your default shell ($shell)
 without using the full path, please run these two commands now:
 
-    echo 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> $rc
+    printf '\n%s\n' 'eval "\$("$DESTINATION/nextstrain" init-shell $shell)"' >> $rc
     eval "\$("$DESTINATION/nextstrain" init-shell $shell)"
 
 The first adds a line to your shell initialization file ($rc) for future

--- a/bin/standalone-installer-windows
+++ b/bin/standalone-installer-windows
@@ -77,7 +77,11 @@ function main([string]$version) {
     # Naively splitting is wrong in the general case, but fine for this check as
     # long as $destination itself doesn't contain a semi-colon.
     if ($destination -notin ($env:PATH -split ";")) {
-        log "Prepending $destination to PATH for current user"
+        log "Making Nextstrain CLI available for the current user"
+
+        # XXX TODO: Replace the commands below with a call to the init-shell
+        # subcommand if it ever supports PowerShell.
+        #   -victorlin, 03 May 2023
 
         # Update it for this session
         $env:PATH = "${destination};${env:PATH}"

--- a/bin/standalone-installer-windows
+++ b/bin/standalone-installer-windows
@@ -108,12 +108,13 @@ function main([string]$version) {
         Remove-Item -Recurse -Force $tmp
     }
 
-    $version = Invoke-Expression "$destination\nextstrain --version"
+    log "Checking installation"
+    $installed_version = Invoke-Expression "$destination\nextstrain --version"
 
     echo @"
 ______________________________________________________________________________
 
-Nextstrain CLI ($version) installed to $destination.
+Nextstrain CLI ($installed_version) installed to $destination.
 "@
 }
 

--- a/bin/standalone-installer-windows
+++ b/bin/standalone-installer-windows
@@ -113,7 +113,7 @@ function main([string]$version) {
     }
 
     log "Checking installation"
-    $installed_version = Invoke-Expression "$destination\nextstrain --version"
+    $installed_version = Invoke-Expression "nextstrain --version"
 
     echo @"
 ______________________________________________________________________________

--- a/nextstrain/cli/command/init_shell.py
+++ b/nextstrain/cli/command/init_shell.py
@@ -66,6 +66,11 @@ def run(opts):
     # issues on the old Bash version found on macOS.
     #   -trs, 7 March 2023
 
+    # XXX TODO: Any changes here should be reflected in
+    # standalone-installer-windows since that does not currently call this
+    # subcommand.
+    #   -victorlin, 03 May 2023
+
     if not INSTALLATION_PATH:
         raise UserError("No shell init required because this is not a standalone installation.")
 

--- a/nextstrain/cli/command/init_shell.py
+++ b/nextstrain/cli/command/init_shell.py
@@ -78,9 +78,10 @@ def run(opts):
 
     if not nextstrain or nextstrain.parent != INSTALLATION_PATH:
         if nextstrain:
-            print(f"# This will mask {nextstrain}")
-            print()
+            # This will mask an existing nextstrain.
+            pass
 
+        # Add INSTALLATION_PATH to front of PATH.
         # This risks duplication if INSTALLATION_PATH is already in PATH but
         # `nextstrain` is found on an earlier PATH entry.  A duplication-free
         # solution would be to detect that condition and *move* the existing
@@ -100,13 +101,11 @@ def run(opts):
         # what's already a edge case, let's not sweat it after all.
         #   -trs, 14 Sept 2022
         init = """
-            # Add %(INSTALLATION_PATH)s to front of PATH
             export PATH=%(INSTALLATION_PATH)s"${PATH:+%(pathsep)s}$PATH"
         """
     else:
-        init = """
-            # PATH already finds this nextstrain at %(INSTALLATION_PATH)s
-        """
+        # PATH already finds this nextstrain at INSTALLATION_PATH.
+        init = ""
 
     print(dedent(init.lstrip("\n")) % {
         "INSTALLATION_PATH": shquote(str(INSTALLATION_PATH)),


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Currently, the UNIX and Windows installers are slightly different. These changes make them less different.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Ran `bin/standalone-installer-unix` locally on macOS with `zsh`
- [ ] Standalone installers checks pass, outputs look good there too
- [x] ~Other checks pass~ failing because of unrelated reasons, but this change should not affect the outcome of those checks

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
