### PR TITLE
runner.conda: Explicitly get latest `main` version

### DIFF
--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -575,7 +575,8 @@ def package_distribution(channel: str, package: str, version: str = None, label:
     # informational-only and subdir is what Conda *actually* uses to
     # differentiate distributions/files/etc.  Use it too so we have the same
     # view of reality.
-    dist = next((d for d in dists if d.get("attrs", {}).get("subdir") == subdir), None)
+    subdir_dists = (d for d in dists if d.get("attrs", {}).get("subdir") == subdir)
+    dist = max(subdir_dists, default=None, key=lambda d: d.get("attrs", {}).get("build_number", 0))
 
     return dist
 

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -46,6 +46,7 @@ import shutil
 import subprocess
 import tarfile
 import traceback
+from packaging.version import parse as parse_version
 from pathlib import Path, PurePosixPath
 from typing import Iterable, NamedTuple, Optional
 from urllib.parse import urljoin, quote as urlquote
@@ -543,12 +544,16 @@ def package_meta(spec: str) -> Optional[dict]:
     return json.loads(metafile.read_bytes())
 
 
-def package_distribution(channel: str, package: str, version: str = None) -> Optional[dict]:
+def package_distribution(channel: str, package: str, version: str = None, label: str = "main") -> Optional[dict]:
     # If *package* is a package spec, convert it just to a name.
     package = package_name(package)
 
     if version is None:
-        version = "latest"
+        version = latest_package_label_version(channel, package, label)
+        if version is None:
+            warn(f"Could not find latest version of package {package!r} with label {label!r}.",
+                 "\nUsing 'latest' version instead, which will be the latest version of the package regardless of label.")
+            version = "latest"
 
     response = requests.get(f"https://api.anaconda.org/release/{urlquote(channel)}/{urlquote(package)}/{urlquote(version)}")
     response.raise_for_status()
@@ -577,6 +582,17 @@ def package_distribution(channel: str, package: str, version: str = None) -> Opt
 
 def package_name(spec: str) -> str:
     return PackageSpec.parse(spec).name
+
+
+def latest_package_label_version(channel: str, package: str, label: str) -> Optional[str]:
+    response = requests.get(f"https://api.anaconda.org/package/{urlquote(channel)}/{urlquote(package)}/files")
+    response.raise_for_status()
+
+    label_files = (file for file in response.json() if label in file.get("labels", []))
+    # Default '0-dev' should be the lowest version according to PEP440
+    # See https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
+    latest_file: dict = max(label_files, default={}, key=lambda file: parse_version(file.get('version', '0-dev')))
+    return latest_file.get("version")
 
 
 class PackageSpec(NamedTuple):


### PR DESCRIPTION
Learned through the conda-base repo's CI job that Anaconda's `/release/{owner_login}/{package_name}/latest` API endpoint returns the latest package version regardless of labels.¹ This means that users can accidentally install test versions of the nextstrain-base package.

I tried various endpoints from the API docs² to see if we can pass the label as a URL param that can allow the filtering to be done on server, but there were no leads in the docs and nothing I tried worked. So this commit adds an explicit check for the latest `main` version by pulling all package files and then filtering for the label and finding the max `upload_time`.

¹ https://github.com/nextstrain/conda-base/issues/26 ² https://api.anaconda.org/docs

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
