### PR TITLE
Revert "Require docutils <0.16 in dev deps to avoid a version conflict"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,7 @@ jobs:
       - name: Install Nextstrain CLI
         run: python3 -m pip install --upgrade '.[dev]'
 
-      - name: Run pytest
-        run: pytest -v
+      - run: ./devel/pytest -v
 
   build-dist:
     runs-on: ubuntu-latest

--- a/devel/pytest
+++ b/devel/pytest
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(realpath "$(dirname "$0")/..")"
+
+set -x
+NEXTSTRAIN_RST_STRICT=1 pytest "$@"

--- a/doc/development.md
+++ b/doc/development.md
@@ -82,7 +82,7 @@ PyPi](https://pypi.org/project/nextstrain-cli).
 
 Tests are run with [pytest](https://pytest.org).  To run everything, use:
 
-    pytest
+    ./devel/pytest
 
 This includes the type annotation and static analysis checks described below.
 

--- a/nextstrain/cli/rst/__init__.py
+++ b/nextstrain/cli/rst/__init__.py
@@ -231,7 +231,7 @@ class MarkEmbeddedHyperlinkReferencesAnonymous(docutils.transforms.Transform):
     default_priority = 480
 
     def apply(self):
-        for ref in self.document.traverse(docutils.nodes.reference):
+        for ref in self.findall(docutils.nodes.reference):
             # Not embedded if it's got a refname, which refers to a target
             # name.
             if ref.get("refname"):
@@ -249,3 +249,13 @@ class MarkEmbeddedHyperlinkReferencesAnonymous(docutils.transforms.Transform):
             # Some refs by this point will already be marked anonymous, but
             # there's no harm in marking "again".
             ref["anonymous"] = 1
+
+    @property
+    def findall(self):
+        try:
+            # docutils 0.18.1 started issuing a PendingDeprecationWarning for
+            # calls to traverse(), so use the findall() method introduced in
+            # that same version when we can.
+            return self.document.findall
+        except AttributeError:
+            return self.document.traverse

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ setup(
 
     extras_require = {
         "dev": [
-            "docutils<0.16",
             "flake8 >=4.0.0",
             "mypy",
             "nextstrain-sphinx-theme>=2022.5",


### PR DESCRIPTION
This reverts commit d2463b72c153ea6720d920baff01003d51ec4c04.

Pip's dependency resolution around docutils no longer appears to be an issue.  We also no longer test on Python 3.6.1 in CI but instead use 3.6.15.

This pin was causing issues in CI tests itself since it was preventing use of newer docutils with fixes for deprecated pkg_resource APIs.  The older docutils versions caused warnings at test time.

Since docutils is also a non-dev dependency and unpinned there, it's also nice to use the same version in dev/test as in non-dev installs.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tests pass locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
