### PR TITLE
ci: Fix silent failure to run pytest on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,9 @@ jobs:
           - os: ubuntu-20.04
             python: '3.6'
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3


### PR DESCRIPTION
The change from `pytest` to `./devel/pytest` in "dev: Set
NEXTSTRAIN_RST_STRICT=1 when running tests" (dc21d8d) caused pytest to
stop running entirely on our Windows jobs but not exit with an error
either.  The default shell there is pwsh (PowerShell) and it silently
(?!) fails to execute the Bash program, maybe because pwsh on Windows
doesn't support shebangs?

Explicitly use bash as the default shell for test-source jobs, similar
to the default we set for other jobs in this workflow.  This covers all
steps in the job.  Even though the "Install Nextstrain CLI" step works
on pwsh now, this guards against future modifications breaking it like I
inadvertently did with the pytest step.

Related-to: <https://github.com/nextstrain/cli/pull/287>




### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Windows tests all run
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
