### PR TITLE
view: Wait for Auspice to start responding before opening the browser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* `nextstrain view` now waits (up to 10s) for Auspice to start responding
+  before automatically opening it in the browser.  This should eliminate the
+  previous behaviour of sometimes opening the browser too soon.
+  ([#291](https://github.com/nextstrain/cli/pull/291))
+
 
 # 7.0.1 (31 May 2023)
 


### PR DESCRIPTION
A big improvement over simply pausing for 2s before opening it and hoping for the best.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually, timing is right, and the timeouts work when I do `nextstrain view --exec cat /var/empty`
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
