### PR TITLE
runner.docker: Use more precise example commands in check-setup failure messages

### DIFF
--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -265,9 +265,9 @@ def test_setup() -> RunnerTestResults:
                     is too old for this version of the CLI (%s).  At least
                     version %s of the image is required.
 
-                    Please run `nextstrain update` to download a newer image.
-                    Afterwards, run `nextstrain check-setup` again and this
-                    version check shoud pass.
+                    Please run `nextstrain update docker` to download a newer
+                    image.  Afterwards, run `nextstrain check-setup docker`
+                    again and this version check shoud pass.
                     """ % (tag, __version__, minimum_tag))
 
         # If we're using the "latest" tag and the image doesn't yet exist


### PR DESCRIPTION
The previous forms relied on defaults and outdated behaviour.  They predate the change to single-runtime application of `nextstrain update` from its previous application to "all runtimes, but in practice only Docker".  The more precise forms will be correct, for example, even if the Docker runtime isn't the default.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] `NEXTSTRAIN_DOCKER_IMAGE=nextstrain/base:build-20180119T045444Z nextstrain check-setup docker` shows new failure message and looks fine
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
