### PR TITLE
dev: Work around issue in CI with Python 3.7.17 on macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,14 +44,30 @@ jobs:
         # Python 3.6 is not available on Ubuntu 22.04, which is what
         # ubuntu-latest points to as of Q4 2022¹, so replace that job with 3.6
         # on Ubuntu 20.04.
+        #   -trs, 22 Nov 2022
         #
         # ¹ <https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/>
+        #
+        # A bodged https://github.com/actions/python-version build of 3.7.17
+        # for macOS mistakenly doesn't include the bz2 module of the stdlib¹,
+        # which breaks us because some of our deps (fsspec, at the least)
+        # assume bz2 is available² (though that will be fixed in its next
+        # release³).  Replace the 3.7 macOS job with a 3.7.16 job.
+        #   -trs, 22 June 2023
+        #
+        # ¹ <https://github.com/actions/setup-python/issues/682>
+        # ² <https://github.com/nextstrain/cli/pull/289#issuecomment-1595417903>
+        # ³ <https://github.com/fsspec/filesystem_spec/pull/1295>
         exclude:
           - os: ubuntu-latest
             python: '3.6'
+          - os: macos-latest
+            python: '3.7'
         include:
           - os: ubuntu-20.04
             python: '3.6'
+          - os: macos-latest
+            python: '3.7.16'
     runs-on: ${{ matrix.os }}
     defaults:
       run:


### PR DESCRIPTION
I was hopeful that actions/setup-python would fix this sooner than later and we could just wait for the upstream fix… but that hasn't happened and now I want to cut a release (which requires working CI), so a workaround it is.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
