### PR TITLE
Use central reusable workflow for building docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,24 +326,11 @@ jobs:
       - uses: ./src/.github/actions/run-integration-tests
 
   doc:
-    name: doc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-
-      - name: Upgrade Python toolchain
-        run: python3 -m pip install --upgrade pip setuptools wheel
-
-      - name: Setup docs build environment
-        run: python3 -m pip install --upgrade -e '.[dev]'
-
-      - name: Make docs with warnings fatalized
-        run: make -C doc dirhtml
-        env:
-          SPHINXOPTS: -W --keep-going
+    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
+    with:
+      docs-directory: doc/
+      pip-install-target: .[dev]
+      make-target: dirhtml
 
   release:
     # Restricted to version tags by the "on: push: tags: …" config at the top.


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This is already used by other repos. It builds the docs with the flags used previously plus an additional flag -n to warn on missing references¹.

¹ https://github.com/nextstrain/.github/blob/cc6f4385a45bd6ed114ab4840416fd90cc46cd1b/.github/workflows/docs-ci.yaml#L43-L48C33

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Docs build runs as expected
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
