### PR TITLE
dev: Exclude Snakemake 7.30.2 when installing from Bioconda for ambient runtime setup

### DIFF
--- a/.github/actions/setup-integration-tests/action.yaml
+++ b/.github/actions/setup-integration-tests/action.yaml
@@ -39,7 +39,7 @@ runs:
 
     # Install software for the "ambient" runner; not supported on Windows.
     - if: runner.os != 'Windows'
-      run: mamba install augur auspice snakemake
+      run: mamba install augur auspice 'snakemake !=7.30.2'
       shell: bash -l -eo pipefail {0}
 
     - run: conda info


### PR DESCRIPTION
This should fix our CI.

The initial Bioconda builds (build number 0) for Snakemake 7.30.2 missed a major bump in Snakemake's minimum Python version (3.7 → 3.9).  This rendered the Bioconda packages for snakemake and snakemake-minimal installable on 3.7 or 3.8 but non-functional at runtime.  Subsequent builds (build number 1 and onwards) of 7.30.2 fixed this oversight, but since the initial builds haven't been yanked/marked broken, the solver still chooses them.¹

Since Conda's package spec syntax doesn't allow for exclusion of specific builds, exclude all of 7.30.2.  It's fine if we never test on this patch version²; Python 3.6–3.8 will get <7.30.2 and 3.9 and onwards will get the already-available subsequent version 7.31.0.

¹ <https://github.com/bioconda/bioconda-recipes/pull/42147>

² It looks like SemVer, but it ain't!  The major version change for
  Python occurred between 7.30.1 and 7.30.2.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
