### PR TITLE
No download? No build dir? No problem!

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,15 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* build: Providing a path to a pathogen build directory is no longer required
+  when the AWS Batch runtime is in use (e.g. with `--aws-batch`) and both the
+  `--attach` and `--no-download` options are given.  This allows usages which
+  just want to check job status or logs to stop providing a meaningless/unused
+  directory.
+  ([#305](https://github.com/nextstrain/cli/pull/305))
+
 
 # 7.2.0 (17 August 2023)
 

--- a/doc/commands/build.rst
+++ b/doc/commands/build.rst
@@ -39,7 +39,7 @@ positional arguments
 
 .. option:: <directory>
 
-    Path to pathogen build directory
+    Path to pathogen build directory.  Required, except when the AWS Batch runtime is in use and both --attach and --no-download are given.  
 
 .. option:: ...
 

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -19,7 +19,7 @@ from types    import SimpleNamespace
 from .argparse    import HelpFormatter, register_commands, register_default_command
 from .command     import build, view, deploy, remote, shell, update, setup, check_setup, login, logout, whoami, version, init_shell, authorization, debugger
 from .debug       import DEBUGGING
-from .errors      import NextstrainCliError
+from .errors      import NextstrainCliError, UsageError
 from .util        import warn
 from .__version__ import __version__ # noqa: F401 (for re-export)
 
@@ -36,11 +36,18 @@ def run(args):
         return opts.__command__.run(opts)
 
     except NextstrainCliError as error:
+        exit_status = 1
+
         if DEBUGGING:
             traceback.print_exc()
         else:
+            if isinstance(error, UsageError):
+                warn(opts.__parser__.format_usage())
+                exit_status = 2
+
             warn(error)
-        return 1
+
+        return exit_status
 
     except AssertionError:
         traceback.print_exc()

--- a/nextstrain/cli/errors.py
+++ b/nextstrain/cli/errors.py
@@ -18,3 +18,9 @@ class UserError(NextstrainCliError):
         formatted_message = dedent(message.lstrip("\n").rstrip()).format(*args, **kwargs)
 
         super().__init__("Error: " + formatted_message)
+
+class UsageError(UserError):
+    """
+    Prints brief command usage before the error message.
+    """
+    pass

--- a/nextstrain/cli/volume.py
+++ b/nextstrain/cli/volume.py
@@ -34,7 +34,7 @@ def store_volume(volume_name):
         def __call__(self, parser, namespace, values, option_strings = None):
             # Add the new volume to the list of volumes
             volumes    = getattr(namespace, "volumes", [])
-            new_volume = NamedVolume(volume_name, Path(values))
+            new_volume = NamedVolume(volume_name, Path(values)) if values else None
             setattr(namespace, "volumes", [*volumes, new_volume])
 
             # Allow the new volume to be found by name on the opts object


### PR DESCRIPTION
Make the `nextstrain build` pathogen `<directory>` optional when `--attach` + `--no-download` are used

This allows usages which just want to check job status/logs to stop    passing in a meaningless/unused directory.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Behaviour manually exercised
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
