### PR TITLE
Ellipsis type; fix broken CI

### DIFF
--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -2,6 +2,8 @@ import argparse
 import builtins
 from argparse import ArgumentParser
 from typing import cast, List, Union, TYPE_CHECKING
+# TODO: Use typing.TypeAlias once Python 3.10 is the minimum supported version.
+from typing_extensions import TypeAlias
 from . import (
     docker as __docker,
     conda as __conda,
@@ -70,7 +72,7 @@ if configured_runner:
             % (configured_runner, runner_name(default_runner)))
 
 
-RunnerExec = List[Union[str, 'builtins.ellipsis']]
+RunnerExec: TypeAlias = List[Union[str, 'builtins.ellipsis']]
 
 
 def register_runners(parser:  ArgumentParser,

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -1,5 +1,4 @@
 import argparse
-import builtins
 from argparse import ArgumentParser
 from typing import cast, List, Union, TYPE_CHECKING
 # TODO: Use typing.TypeAlias once Python 3.10 is the minimum supported version.
@@ -14,7 +13,7 @@ from . import (
 from .. import config, env, hostenv
 from ..argparse import DirectoryPath, SKIP_AUTO_DEFAULT_IN_HELP
 from ..errors import UserError
-from ..types import Env, Options, RunnerModule
+from ..types import EllipsisType, Env, Options, RunnerModule
 from ..util import prose_list, runner_name, runner_module, runner_help, warn
 from ..volume import NamedVolume
 
@@ -72,7 +71,7 @@ if configured_runner:
             % (configured_runner, runner_name(default_runner)))
 
 
-RunnerExec: TypeAlias = List[Union[str, 'builtins.ellipsis']]
+RunnerExec: TypeAlias = List[Union[str, EllipsisType]]
 
 
 def register_runners(parser:  ArgumentParser,

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -4,6 +4,7 @@ Type definitions for internal use.
 
 import argparse
 import builtins
+import sys
 import urllib.parse
 from pathlib import Path
 from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
@@ -11,6 +12,12 @@ from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 # TODO: Use typing.TypeAlias once Python 3.10 is the minimum supported version.
 from typing_extensions import Protocol, TypeAlias
 from .volume import NamedVolume
+
+# Re-export EllipsisType so we can paper over its absence from older Pythons
+if sys.version_info >= (3, 10):
+    from types import EllipsisType
+else:
+    EllipsisType: TypeAlias = 'builtins.ellipsis'
 
 """
 An immutable mapping of (*name*, *value*) pairs representing a set of
@@ -33,7 +40,7 @@ RunnerSetupStatus = Optional[bool]
 
 RunnerTestResults = List['RunnerTestResult']
 RunnerTestResult  = Tuple[str, 'RunnerTestResultStatus']
-RunnerTestResultStatus: TypeAlias = Union[bool, None, 'builtins.ellipsis']
+RunnerTestResultStatus: TypeAlias = Union[bool, None, EllipsisType]
 
 RunnerUpdateStatus = Optional[bool]
 

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -8,7 +8,8 @@ import urllib.parse
 from pathlib import Path
 from typing import Any, Iterable, List, Mapping, Optional, Tuple, Union
 # TODO: Use typing.Protocol once Python 3.8 is the minimum supported version.
-from typing_extensions import Protocol
+# TODO: Use typing.TypeAlias once Python 3.10 is the minimum supported version.
+from typing_extensions import Protocol, TypeAlias
 from .volume import NamedVolume
 
 """
@@ -32,7 +33,7 @@ RunnerSetupStatus = Optional[bool]
 
 RunnerTestResults = List['RunnerTestResult']
 RunnerTestResult  = Tuple[str, 'RunnerTestResultStatus']
-RunnerTestResultStatus = Union[bool, None, 'builtins.ellipsis']
+RunnerTestResultStatus: TypeAlias = Union[bool, None, 'builtins.ellipsis']
 
 RunnerUpdateStatus = Optional[bool]
 


### PR DESCRIPTION
Two related commits:

----

**dev: Fix new errors in type checking around the type of Ellipsis (...)**

pyright 1.1.325 (released yesterday) added support for @type_check_only decorators¹, which were added (a year ago) to the builtins.ellipsis type of the stdlib typeshed².  This type is available only during type-checking and doesn't actually exist at runtime, but previously pyright didn't care about that (and mypy still doesn't).  Now it does, noticed thanks to scheduled CI, and throws an error like:

    "ellipsis" is marked as @type_check_only and can be used only in
    type annotations (reportGeneralTypeIssues)

Explicitly clarify to pyright that our variable is a type alias³ and not a value also used at runtime so it knows its ok to use the type of Ellipsis (via a forward reference to the now-you-see-it, now-you-don't builtins.ellipsis).

Relatedly, we can switch from 'builtins.ellipsis' → types.EllipsisType on Python ≥3.10⁴ and stop using the private/internal type for Ellipsis. I'll do that in the subsequent commit.

¹ <https://github.com/microsoft/pyright/pull/5817>

² <https://github.com/python/typeshed/commit/a92da58328aa259184ff45bb7408e82426fb563e>
  <https://github.com/python/typeshed/pull/8531>

³ <https://docs.python.org/3/library/typing.html#typing.TypeAlias>
  <https://peps.python.org/pep-0613/>

⁴ <https://docs.python.org/3/library/types.html#types.EllipsisType>
  <https://github.com/python/cpython/issues/85976>

----

**dev: Use types.EllipsisType instead of 'builtins.ellipsis' when we can**

The former is preferable as its not a private/internal type¹, but it's only available on on Python ≥3.10.²

¹ <https://github.com/python/cpython/issues/85976>
² <https://docs.python.org/3/library/types.html#types.EllipsisType>

---

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Works locally on 3.8 and 3.11
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
