### PR TITLE
view: Respect HOST and PORT as defaults for --host and --port

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,12 @@ development source code and as such may not be routinely kept up to date.
   directory.
   ([#305](https://github.com/nextstrain/cli/pull/305))
 
+## Bug fixes
+
+* The `HOST` and `PORT` environment variables are now respected by `nextstrain
+  view`.  They provide defaults when `--host` and/or `--port` aren't provided.
+  ([#310](https://github.com/nextstrain/cli/pull/310))
+
 
 # 7.2.0 (17 August 2023)
 

--- a/doc/commands/view.rst
+++ b/doc/commands/view.rst
@@ -97,11 +97,11 @@ options
 
 .. option:: --host <ip/hostname>
 
-    Listen on the given hostname or IP address instead of the default 127.0.0.1
+    Listen on the given hostname or IP address instead of the default 127.0.0.1.  You may also set the :envvar:`HOST` environment variable to change the default.
 
 .. option:: --port <number>
 
-    Listen on the given port instead of the default port 4000
+    Listen on the given port instead of the default port 4000.  You may also set the :envvar:`PORT` environment variable to change the default.
 
 runtime selection options
 =========================
@@ -176,3 +176,15 @@ development options for --docker
 
     Additional arguments to pass to `docker run`
 
+In some contexts, it may be preferable to provide environment variables
+instead of command-line options:
+
+.. envvar:: HOST
+
+    Hostname or IP address on which to listen by default.  Ignored if
+    :option:`--host` or :option:`--allow-remote-access` is provided.
+
+.. envvar:: PORT
+
+    Port on which to listen by default.  Ignored if :option:`--port` is
+    provided.

--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -49,6 +49,7 @@ from multiprocessing import Process, ProcessError
 import re
 import requests
 import webbrowser
+from inspect import cleandoc
 from os import environ
 from pathlib import Path
 from socket import getaddrinfo, AddressFamily, SocketKind, AF_INET, AF_INET6, IPPROTO_TCP
@@ -59,6 +60,11 @@ from ..argparse import add_extended_help_flags, SUPPRESS, SKIP_AUTO_DEFAULT_IN_H
 from ..runner import docker, ambient, conda, singularity
 from ..util import colored, remove_suffix, warn
 from ..volume import NamedVolume
+
+
+# Respect defaults for HOST and PORT set in the environment
+HOST = environ.get("HOST") or "127.0.0.1"
+PORT = environ.get("PORT") or "4000"
 
 
 # Avoid text-mode browsers
@@ -111,15 +117,17 @@ def register_parser(subparser):
 
     parser.add_argument(
         "--host",
-        help    = "Listen on the given hostname or IP address instead of the default %(default)s",
+        help    = "Listen on the given hostname or IP address instead of the default %(default)s.  "
+                  "You may also set the :envvar:`HOST` environment variable to change the default.",
         metavar = "<ip/hostname>",
-        default = "127.0.0.1")
+        default = HOST)
 
     parser.add_argument(
         "--port",
-        help    = "Listen on the given port instead of the default port %(default)s",
+        help    = "Listen on the given port instead of the default port %(default)s.  "
+                  "You may also set the :envvar:`PORT` environment variable to change the default.",
         metavar = "<number>",
-        default = 4000)
+        default = PORT)
 
     # Positional parameters
     parser.add_argument(
@@ -138,6 +146,21 @@ def register_parser(subparser):
         parser,
         exec    = ["auspice", "view", "--verbose", "--datasetDir=.", "--narrativeDir=."],
         runners = [docker, ambient, conda, singularity])
+
+    parser.epilog = cleandoc("""
+        In some contexts, it may be preferable to provide environment variables
+        instead of command-line options:
+
+        .. envvar:: HOST
+
+            Hostname or IP address on which to listen by default.  Ignored if
+            :option:`--host` or :option:`--allow-remote-access` is provided.
+
+        .. envvar:: PORT
+
+            Port on which to listen by default.  Ignored if :option:`--port` is
+            provided.
+        """)
 
     return parser
 


### PR DESCRIPTION
These are widely-used conventions, and also Auspice recommends setting PORT when it runs into a "port in use" error trying to bind at start up. It's good to make that suggestion work thru `nextstrain view`.

Reported by @corneliusroemer in Slack.¹

¹ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1694718932379359>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
