### PR TITLE
runner.conda: Plug isolation leaks related to Python

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,15 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* We've plugged some isolation leaks in the Conda runtime where the
+  [Python user site directory](https://docs.python.org/3/library/site.html),
+  e.g. `~/.local/lib/pythonX.Y/site-packages`, as well as the
+  [`PYTHONPATH` and `PYTHONHOME` environment variables](https://docs.python.org/3/using/cmdline.html#environment-variables)
+  could influence and break the runtime.
+  ([#311](https://github.com/nextstrain/cli/pull/311))
+
 
 # 7.3.0.post1 (19 September 2023)
 
@@ -21,6 +30,7 @@ _See also changes in 7.3.0 which was an unreleased version._
 ## Development
 
 * Update CI to test against the SingularityCE 3.x series only ([#314](https://github.com/nextstrain/cli/pull/314))
+
 
 # 7.3.0 (19 September 2023)
 


### PR DESCRIPTION
By default Python will search for modules in the user site directory, e.g. ~/.local/lib/python3.10/site-packages/.  This is an isolation leak that can cause conflicts with our Conda runtime since its not containerized, and we observed such an issue during a workshop.  Plug that leak by both disabling the searching of a user site directory entirely (the proximate issue) and pointing the whole Python user base directory to an alternate location (a preventative measure against other user base directory usages).

Similarly, PYTHONPATH and (probably more rarely) PYTHONHOME also have the potential to cause similar issues, so we now ensure they're unset when entering our Conda runtime.  I reviewed other environment variables used by Python¹ and they seem reasonable to leave as-is (at least at this point).  There are a few which could cause issues, but I expect they'd be limited to usage for debugging/troubleshooting/interactive use.

Resolves <https://github.com/nextstrain/cli/issues/309>.

¹ <https://docs.python.org/3/using/cmdline.html#environment-variables>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
