### PR TITLE
Avoid fsspec/s3fs 2023.9.1 due to errors caused by `auto_mkdir`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ development source code and as such may not be routinely kept up to date.
   view`.  They provide defaults when `--host` and/or `--port` aren't provided.
   ([#310](https://github.com/nextstrain/cli/pull/310))
 
+* Updated fsspec and s3fs dependencies to avoid version 2023.9.1, since they
+  caused `nextstrain build --aws-batch` invocations to fail.
+  ([#313](https://github.com/nextstrain/cli/pull/313))
 
 # 7.2.0 (17 August 2023)
 

--- a/setup.py
+++ b/setup.py
@@ -119,8 +119,12 @@ setup(
         # <https://github.com/nextstrain/cli/issues/133> for more background.
         #
         # What a mess.
-        "fsspec",
-        "s3fs[boto3] >=2021.04.0",
+        #
+        # Avoiding 2023.9.1 due to change in `auto_mkdir` parameter in
+        # https://github.com/fsspec/filesystem_spec/pull/1358 that causes the
+        # error described in https://github.com/fsspec/s3fs/issues/790
+        "fsspec !=2023.9.1",
+        "s3fs[boto3] >=2021.04.0, !=2023.9.1",
     ],
 
     extras_require = {


### PR DESCRIPTION
## Description of proposed changes

Changes to the `auto_mkdir` parameter in https://github.com/fsspec/filesystem_spec/pull/1358 leads to the error described in https://github.com/fsspec/s3fs/issues/790.

Upstream fixes to come soon via https://github.com/fsspec/filesystem_spec/pull/1365 but good to avoid versions that we know are broken.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
