### PR TITLE
dev: Test against the SingularityCE 3.x series in CI

### DIFF
--- a/.github/actions/setup-integration-tests/action.yaml
+++ b/.github/actions/setup-integration-tests/action.yaml
@@ -84,11 +84,14 @@ runs:
         pushd "$(mktemp -d)"
         export "$(grep UBUNTU_CODENAME /etc/os-release)"
 
-        # Download latest SingularityCE .deb for this version of Ubuntu
+        # Download latest SingularityCE 3.x series .deb for this version of Ubuntu
+        #
+        # XXX TODO: Start testing the SingularityCE 4.x series.
+        #   -trs, 19 Sept 2023
         url="$(
           curl -fsSL --proto '=https' -H "Authorization: Bearer $GITHUB_TOKEN" \
-            https://api.github.com/repos/sylabs/singularity/releases/latest \
-              | jq -r '.assets | map(select(.name | endswith("\(env.UBUNTU_CODENAME)_amd64.deb"))) | .[0].browser_download_url')"
+            "https://api.github.com/repos/sylabs/singularity/releases?per_page=100" \
+              | jq -r 'map(select(.tag_name | startswith("v3."))) | .[0].assets | map(select(.name | endswith("\(env.UBUNTU_CODENAME)_amd64.deb"))) | .[0].browser_download_url')"
 
         curl -fsSL --proto '=https' "$url" > singularity.deb
 


### PR DESCRIPTION
The release of SingularityCE 4.0.0 a few hours ago¹ caused a failure during CI for the release of Nextstrain CLI 7.3.0.²  We got unlucky as that release's CI was the first to encounter the issue due to timing. We can test the compatibility of SingularityCE 4.x with both our CI setup process and Singularity runtime at some later point.

¹ <https://github.com/sylabs/singularity/releases/tag/v4.0.0>
² <https://github.com/nextstrain/cli/actions/runs/6238951959>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
