### PR TITLE
standalone-installer-unix: Use ~/.profile when the default shell is sh

### DIFF
--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -201,6 +201,17 @@ shell-rc() {
             esac;;
         zsh)
             echo "${ZDOTDIR:-~}/.zshrc";;
+        sh)
+            # sh, whether a historic version or bash in sh-compat mode, doesn't
+            # use any default startup file for interactive shells.  It only
+            # uses a default startup file for login shells.  We'll have to
+            # assume here that anyone using sh as their default shell will also
+            # be using login shells appropriately.  On macOS, at least, common
+            # terminal emulators spawn login shells (see commentary above).
+            #   -trs, 26 September 2023
+
+            # shellcheck disable=SC2088
+            echo "~/.profile";;
         *)
             # A decent guess?
             #


### PR DESCRIPTION
We were suggesting nonsense (~/.shrc) due to our final fallback/guess. Instead, handle sh specifically and correctly.

Resolves <https://github.com/nextstrain/cli/issues/319>.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manual test with default shell of `/bin/sh` works
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
