### PR TITLE
dev: Require Mypy <1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setup(
     extras_require = {
         "dev": [
             "flake8 >=4.0.0",
-            "mypy",
+            "mypy <1.6",
             "nextstrain-sphinx-theme>=2022.5",
             "pytest; python_version != '3.9'",
             "pytest !=7.0.0; python_version == '3.9'",


### PR DESCRIPTION
Version 1.6 released this morning dropped support for targeting Python 3.6, and also introduced other type checking issues, breaking CI.  While we'll also drop Python 3.6 soon¹, we haven't yet.  We may also drop Mypy² sooner than later and just use Pyright², but again, we haven't yet.

Resolves <https://github.com/nextstrain/cli/issues/320>.

¹ <https://github.com/nextstrain/cli/issues/136#issuecomment-1622294693>
² <https://github.com/nextstrain/cli/issues/320#issuecomment-1756429861>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
