### PR TITLE
authn: Handle case when a user is not in any group

### DIFF
--- a/nextstrain/cli/authn.py
+++ b/nextstrain/cli/authn.py
@@ -48,7 +48,7 @@ class User:
         assert session.id_claims
 
         self.username = session.id_claims["cognito:username"]
-        self.groups   = session.id_claims["cognito:groups"]
+        self.groups   = session.id_claims.get("cognito:groups", [])
         self.email    = session.id_claims["email"]
 
         self.http_authorization = f"Bearer {session.id_token}"


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

In this case, the "cognito:groups" claim does not exist. Previously, this resulted in a KeyError upon login and whoami commands.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] `nextstrain login` and `nextstrain whoami` works locally for group-less user in testing environment
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
