### PR TITLE
Cast err.response to Response class for Pyright

### DIFF
--- a/nextstrain/cli/remote/nextstrain_dot_org.py
+++ b/nextstrain/cli/remote/nextstrain_dot_org.py
@@ -683,6 +683,7 @@ def raise_for_status(response: requests.Response) -> None:
         response.raise_for_status()
 
     except requests.exceptions.HTTPError as err:
+        assert type(err.response) is requests.Response
         status = err.response.status_code
 
         if status == 400:


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

2 weeks ago¹, Pyright on 3.10 CI started failing with an error:

    "status_code" is not a known member of "None"

I looked at the requests source code² and it makes sense. However, I was not able to reproduce the CI error locally and don't understand why it only happens on 3.10. Hopefully this addresses the issue.

¹ https://github.com/nextstrain/cli/actions/runs/6605300519/job/17940321340#step:5:88
² https://github.com/psf/requests/blob/839a8edec37c81a18ac8332cfbd44f44e1ae6206/src/requests/exceptions.py#L19

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
