### PR TITLE
Address new Pyright error

### DIFF
--- a/nextstrain/cli/argparse.py
+++ b/nextstrain/cli/argparse.py
@@ -6,7 +6,7 @@ import sys
 from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError, SUPPRESS, _SubParsersAction # pyright: ignore[reportPrivateUsage]
 from itertools import chain, takewhile
 from pathlib import Path
-from textwrap import indent
+from textwrap import indent as indent_text
 from types import SimpleNamespace
 from typing import Iterable, Optional, Tuple
 from .rst import rst_to_text
@@ -49,8 +49,8 @@ class HelpFormatter(ArgumentDefaultsHelpFormatter):
         super().__init__(prog, indent_increment, max_help_position, width)
 
     # Based on argparse.RawDescriptionHelpFormatter's implementation
-    def _fill_text(self, text, width, prefix):
-        return indent(rst_to_text(text, width), prefix)
+    def _fill_text(self, text, width, indent):
+        return indent_text(rst_to_text(text, width), prefix=indent)
 
     # Based on argparse.RawTextHelpFormatter's implementation
     def _split_lines(self, text, width):


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

The latest version of Pyright exposed a new error for this project:

    argparse.py:52:9 - error: Method "_fill_text" overrides class "HelpFormatter" in an incompatible manner
      Parameter 4 name mismatch: base parameter is named "indent", override parameter is named "prefix" (reportIncompatibleMethodOverride)

I don't think the issue resulted in badly rendered docs, but nevertheless it's easy to address this by changing a couple names.

## Related issue(s)

Fixes the issue that caused [today's scheduled CI](https://github.com/nextstrain/cli/actions/runs/7118237967) to fail.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
