### PR TITLE
remote: Show more possible reasons for S3 access error

### DIFF
--- a/nextstrain/cli/remote/s3.py
+++ b/nextstrain/cli/remote/s3.py
@@ -225,9 +225,11 @@ def split_url(url: urllib.parse.ParseResult) -> Tuple[S3Bucket, str]:
 
     except ClientError:
         raise UserError(f"""
-            No bucket exists with the name "{bucket.name}".
+            Unable to read from S3 bucket "{bucket.name}". Possible reasons:
 
-            Buckets are not automatically created for safety reasons.
+            1. Your AWS credentials are invalid.
+            2. Your AWS credentails are valid but lack permissions to the bucket.
+            3. The bucket does not exist (buckets are not automatically created for safety reasons).
             """)
 
     return bucket, prefix


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Previously, other reasons detailed in the changes would show an error message saying "no bucket exists" even if it does exist.

Update the error text to describe more possible reasons based on docs for S3.Client.head_bucket.¹ and local testing. This list might not be exhaustive, but I can't come up with any other scenarios.

¹ <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/head_bucket.html>

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- [Internal inquiry](https://bedfordlab.slack.com/archives/C036L7V615F/p1703710506208669)
- Closes #56

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
