### PR TITLE
runner.singularity: Explicitly support Apptainer's `singularity` when checking versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,13 @@ This release drops support for Python versions 3.6 and 3.7 and adds support for
   when the default shell is sh.
   ([#321](https://github.com/nextstrain/cli/pull/321))
 
+* The Singularity runtime once again supports Apptainer's `singularity`
+  executable.  The minimum version checking added in 7.0.0 broke usage of the
+  Singularity runtime with Apptainer (compared with SingularityCE).  Our intent
+  is to support both lineages of Singularity.  Thanks to @osageorange for
+  raising this issue and testing the fix!
+  ([#343](https://github.com/nextstrain/cli/pull/343))
+
 
 # 7.4.0 (21 September 2023)
 


### PR DESCRIPTION
My intent was (and remains) to try to maintain compatibility with both SingularityCE and Apptainer after the Singularity fork.  I didn't realize/recall that Apptainer restarted version numbering when I added this version inspection!

It would be most ideal if Apptainer's `singularity` executable reported the equivalent/compatible SingularityCE version, but that's understandably difficult and so I get why it reports the Apptainer version instead.

Thanks to @osageorange for raising this issue, testing this patch, and reporting back that it works!

As SingularityCE and Apptainer continue to diverge, a more complicated treatment of them may be needed, but for now this should suffice.

Resolves <https://github.com/nextstrain/cli/issues/329>.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
