### PR TITLE
dev: Appease Pyright 1.1.345's changed type checking of tuple slices

### DIFF
--- a/nextstrain/cli/command/view.py
+++ b/nextstrain/cli/command/view.py
@@ -387,7 +387,7 @@ def print_url(host, port, available_paths):
     print()
 
 
-def resolve(host, port) -> Tuple[str, int]:
+def resolve(host: str, port: str) -> Tuple[str, int]:
     """
     Resolves *host* to an address and *port* to a number, if either is a name.
 
@@ -402,9 +402,9 @@ def resolve(host, port) -> Tuple[str, int]:
     ip4 = [a for a in addrs if a.family is AF_INET]
     ip6 = [a for a in addrs if a.family is AF_INET6]
 
-    return ip4[0].sockaddr[0:2] if ip4 \
-      else ip6[0].sockaddr[0:2] if ip6 \
-      else (host, int(port))
+    return (ip4[0].sockaddr[0], ip4[0].sockaddr[1]) if ip4 \
+      else (ip6[0].sockaddr[0], ip6[0].sockaddr[1]) if ip6 \
+      else (str(host), int(port))
 
 
 class AddressInfo(NamedTuple):


### PR DESCRIPTION
A slice like x[0:2] may evaluate to ('a',) or ('a', 'b',) depending on the length of x.  Pyright changed its checking of this slice behaviour for tuples in 1.1.345 (released 4 days ago)¹, which started raising issues with this code in CI.

While we humans know that the sockaddr tuples here always have at least two elements, Pyright does not.  I think Pyright could do better here as it knows the type of sockaddr is

    Tuple[str, int] | Tuple[str, int, int, int]

and thus I think should be able to know for sure the type of a 0:2 slice.  Instead, it evaluates the slice type to an ambiguous

    Tuple[str | int, ...]

which is incompatible with our declared return type.

I went to report this behaviour regression, but someone's already beat me to it.²

¹ <https://github.com/microsoft/pyright/releases/tag/1.1.345>
² <https://github.com/microsoft/pyright/issues/6958>
## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
