### PR TITLE
devel/create-github-release: Reflow paragraphs in changelog Markdown to single long lines

### DIFF
--- a/devel/create-github-release
+++ b/devel/create-github-release
@@ -31,7 +31,7 @@ main() {
         --title "$version" \
         --target "$commit" \
         ${pre_release:+--prerelease} \
-        --notes-file <(preamble; "$devel"/changes "$version") \
+        --notes-file <(preamble; "$devel"/changes "$version" | "$devel"/reflow-markdown) \
         "${assets[@]}"
 }
 

--- a/devel/reflow-markdown
+++ b/devel/reflow-markdown
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Reflows paragraphs in Markdown to single long lines while preserving verbatim
+# code blocks, lists, and what not.
+set -euo pipefail
+
+devel="$(dirname "$0")"
+
+main() {
+    pandoc --wrap none --from markdown --to markdown
+}
+
+pandoc() {
+    # XXX TODO: This relies on Docker being available, which it typically is in
+    # our development environments (local and CI).  If Docker ever poses a
+    # burden, we could switch to just-in-time downloading of static binaries
+    # from <https://github.com/jgm/pandoc/releases/latest> and exec-ing those à
+    # la what our devel/pyoxidizer does.
+    #   -trs, 18 Jan 2024
+    "$devel"/within-container --interactive pandoc/core "$@"
+}
+
+main "$@"


### PR DESCRIPTION
This is necessary to work around GitHub's rendering of release notes which treats newlines in the Markdown as hard line breaks instead of soft line breaks (which is more standard).  GitHub itself isn't consistent and treats newlines as hard or soft in different places.¹

This has bugged me for a while, and I've always resorted to hand-correcting the release notes after the release is created.  But that's annoying and means that the crappy formatting still appears in emails and other notifications triggered by the release creation event. I'll be glad to have Pandoc doing this for me instead!  It hadn't occurred to me to use Pandoc for this until now.

¹ <https://github.com/orgs/community/discussions/57633>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
