### PR TITLE
build: Error if overlays are given for a runtime other than Docker or Singularity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,17 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* `nextstrain build` now errors if a [development overlay option][] such as
+  `--augur` or `--auspice` is given when using a runtime without support for
+  those (anything but Docker or Singularity).  Previously, it would silently
+  ignore those options when unsupported by the runtime.  The new behaviour
+  matches the behaviour of `nextstrain shell` since 5.0.0.
+  ([#354](https://github.com/nextstrain/cli/pull/354))
+
+[development overlay option]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/build/#development-options-for-docker
+
 
 # 8.0.1 (29 January 2024)
 

--- a/devel/release
+++ b/devel/release
@@ -102,6 +102,10 @@ update-changelog() {
     # preserving the __NEXT__ heading itself.
     perl -pi -e "s/(?<=^# __NEXT__$)/\n\n\n# $new_version ($today)/" "$changes_file"
 
+    # Replace any occurrences of __NEXT__ under the new version heading, e.g.
+    # for use in doc URLs that should point to the released version.
+    perl -pi -e "s/__NEXT__/$new_version/g if /^# \\Q$new_version/ ... /^# /" "$changes_file"
+
     # Remove the __NEXT__ heading and the sentence «The "__NEXT__" heading
     # below…» for the next commit, but leave the working tree untouched.
     perl -0p -e '

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -163,7 +163,7 @@ def register_arguments(parser) -> None:
 
 
 def run(opts, argv, working_volume = None, extra_env: Env = {}, cpus: int = None, memory: int = None) -> int:
-    # Unlike other runners, the AWS Bach runner currently *requires* a working
+    # Unlike other runners, the AWS Batch runner currently *requires* a working
     # dir in most usages.  This is ok as we only provide the AWS Batch runner
     # for commands which also require a working dir (e.g. build), whereas other
     # runners also work with commands that don't.


### PR DESCRIPTION
Mirrors the existing behaviour of `nextstrain shell`, introduced by "shell: Add support for the managed Conda runtime" (6e2d73d).  It was an oversight to not do the same for `nextstrain build` at the same time.

----

Two other smaller changes too; see their commit messages.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
