### PR TITLE
Standalone builds for macOS aarch64 (aka arm64, Apple Silicon, M1/M2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,13 +99,6 @@ jobs:
         #
         # ¹ https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_distributing_binary_portability.html
         # ² https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_status.html#an-official-build-environment
-        #
-        # XXX TODO: GitHub doesn't yet host any runners on M1 (Apple Silicon,
-        # aarch64, arm64) hardware, and we don't have M1 hardware on which to
-        # self-host a runner.  Amazon's mac2.metal EC2 instances are M1, but
-        # they cost a minimum of ~$15/day.  It would be cheaper to buy an M1
-        # Mac Mini for ~$700 which would pay for itself in less than 2 months.
-        #   -trs, 31 May 2022
         include:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -113,6 +106,10 @@ jobs:
 
           - os: macos-11
             target: x86_64-apple-darwin
+            exe: nextstrain
+
+          - os: macos-14
+            target: aarch64-apple-darwin
             exe: nextstrain
 
           - os: windows-2019
@@ -283,13 +280,12 @@ jobs:
         # end-user runtime issues with our binaries (e.g. missing DLLs).  Such
         # fresh CI machines are not readily available, however, since
         # pre-installation is convenient for builds.
-        #
-        # XXX TODO: macOS aarch64 (M1, Apple Silicon, arm64); see above.
         include:
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           - { os: macos-11,     target: x86_64-apple-darwin }
           - { os: macos-12,     target: x86_64-apple-darwin }
+          - { os: macos-14,     target: aarch64-apple-darwin }
           - { os: windows-2019, target: x86_64-pc-windows-msvc }
           - { os: windows-2022, target: x86_64-pc-windows-msvc }
 
@@ -370,6 +366,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: standalone-x86_64-apple-darwin
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: standalone-aarch64-apple-darwin
 
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* We now produce standalone installation archives for macOS running on aarch64
+  hardware (aka arm64, Apple Silicon, M1/M2).
+  ([#357](https://github.com/nextstrain/cli/pull/357))
+
 
 # 8.0.1 (29 January 2024)
 


### PR DESCRIPTION
GitHub released public runners.¹  Great timing too, as I was just about
to look into using the ARM hardware that's available for macOS with
GitHub's (paid) large runners².  This also beats operating a self-hosted
runner, whether that's on EC2³ or our own Mac Mini.⁴

And the icing on the cake is that everything Just Worked by merely
enabling builds for this architecture.  \o/  High fives all around,
everyone.

Changes to the standalone installer to follow separately⁵, as those need
to be held for merge until after the first release with these builds
available.

¹ <https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/>
² <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1706556690621389>
³ <https://github.com/tsibley/blab-standup/blob/e7e2516fc40856a94b54eb83077d8f4bafd16914/2022-09-14.md>
⁴ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1670979565748349?thread_ts=1670963819.691499&cid=C01LCTT7JNN>
⁵ <https://github.com/nextstrain/cli/pull/358>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
