### PR TITLE
standalone-installer-unix: Use new aarch64 builds for macOS

### DIFF
--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -39,6 +39,7 @@ jobs:
           - ubuntu-22.04
           - macos-11
           - macos-12
+          - macos-14      # (aarch64)
           - windows-2019
           - windows-2022
 

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -20,16 +20,16 @@ shopt -s failglob
 # Globals declared here to make them more obvious, but set by main() to avoid
 # source ordering requirements and delay execution until the full file is
 # parsed.
-declare KERNEL TARGET DESTINATION VERSION
+declare VERSION KERNEL TARGET DESTINATION
 
 # Wrap everything in a function which we call at the end to avoid execution of
 # a partially-downloaded program.
 main() {
+    VERSION="${1:-${VERSION:-latest}}"
+
     KERNEL="${KERNEL:-$(uname -s)}"
     TARGET="${TARGET:-$(target-triple)}"
     DESTINATION="${DESTINATION:-${NEXTSTRAIN_HOME:-$HOME/.nextstrain}/cli-standalone}"
-
-    VERSION="${1:-${VERSION:-latest}}"
 
     local archive archive_url tmp
 
@@ -115,9 +115,23 @@ target-triple() {
             ;;
 
         Darwin)
-            [[ "$machine" == x86_64 || "$machine" == arm64 ]] || die "unsupported architecture: $machine"
-            [[ "$machine" != arm64 ]] || pgrep -qU _oahd 2>/dev/null || die "Rosetta 2 not enabled.  Please run:"$'\n\n'"    softwareupdate --install-rosetta"$'\n\n'"and then retry this installation of Nextstrain CLI."
-            machine=x86_64
+            # Rosetta 2 will not be needed for the standalone version of
+            # Nextstrain CLI itself as of 8.2.0.  The Conda runtime still
+            # requires it and the Docker runtime can benefit from it, but we
+            # now check for it in their setup instead.
+            #  -trs, 1 Feb 2024
+               version-gte 8.2.0 \
+            || [[ "$machine" != arm64 ]] \
+            || pgrep -qU _oahd 2>/dev/null \
+            || die "Rosetta 2 not enabled.  Please run:"$'\n\n'"    softwareupdate --install-rosetta"$'\n\n'"and then retry this installation of Nextstrain CLI."
+
+            # aarch64 builds will only be available starting with 8.2.0.  Older
+            # versions only provide x86_64, which will run under Rosetta.
+            case "$machine" in
+                x86_64) ;;
+                arm64) version-gte 8.2.0 && machine=aarch64 || machine=x86_64;;
+                *) die "unsupported architecture: $machine";;
+            esac
             vendor=apple
             os=darwin
             ;;
@@ -127,6 +141,16 @@ target-triple() {
     esac
 
     echo "$machine-$vendor-$os"
+}
+
+version-gte() {
+    local minimum="$1"
+
+    # If $minimum sorts before $VERSION, then $VERSION is at least ≥$minimum.
+    # Note that non-numeric values sort by byte order, so "latest" and
+    # "pr-build/123" and so on end up after (greater than) a numeric value like
+    # 8.1.0.  Both macOS/BSD sort and GNU sort support -V.
+    [[ $(printf '%s\n%s\n' "$minimum" "$VERSION" | sort -V | head -n1) == "$minimum" ]]
 }
 
 default-shell() {


### PR DESCRIPTION
Conditions on the Nextstrain CLI version being requested, as aarch64 builds¹ will only be available going forward for new releases.  Assumes the next release will be 8.2.0!

Disables Rosetta check when using an aarch64 build, as the checks will be done at the runtime-level instead by `nextstrain setup` and `nextstrain check-setup`.²

We must wait to merge this until after the first release (i.e. 8.2.0) of the changes it depends on above.

¹ <https://github.com/nextstrain/cli/pull/357>
² <https://github.com/nextstrain/cli/pull/361>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] https://github.com/nextstrain/cli/pull/357
- [x] https://github.com/nextstrain/cli/pull/361
- [x] Release 8.2.0
- [ ] Checks pass. The macos-14 standalone-installers test is expected to fail until the first release with aarch64 support is made, which is a precondition of merging this PR.
- [ ] https://github.com/nextstrain/docs.nextstrain.org/pull/186

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
