### PR TITLE
Check if Rosetta 2 is enabled in the Conda and Docker runner checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,15 @@ development source code and as such may not be routinely kept up to date.
   ([#357](https://github.com/nextstrain/cli/pull/357),
   [#358](https://github.com/nextstrain/cli/pull/358))
 
+* The Conda and Docker runtime checks performed by `nextstrain setup` and
+  `nextstrain check-setup` now test if Rosetta 2 is enabled for macOS on
+  aarch64 (aka arm64, Apple Silicon, M1/M2) hardware.  Rosetta is required for
+  the Conda runtime and optional, but recommended, for the Docker runtime.
+  Previously only the standalone installer checked for Rosetta, but starting
+  with this release it will not.
+  ([#361](https://github.com/nextstrain/cli/pull/361),
+  [#358](https://github.com/nextstrain/cli/pull/358))
+
 * `nextstrain build` now errors if a [development overlay option][] such as
   `--augur` or `--auspice` is given when using a runtime without support for
   those (anything but Docker or Singularity).  Previously, it would silently

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -87,7 +87,7 @@ from urllib.parse import urljoin, quote as urlquote
 from ..errors import InternalError
 from ..paths import RUNTIMES
 from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
-from ..util import capture_output, colored, exec_or_return, runner_tests_ok, warn
+from ..util import capture_output, colored, exec_or_return, runner_tests_ok, test_rosetta_enabled, warn
 
 
 RUNTIME_ROOT = RUNTIMES / "conda/"
@@ -467,10 +467,11 @@ def test_support() -> RunnerTestResults:
         else:
             return False
 
-
     return [
         ('operating system is supported',
             supported_os()),
+
+        *test_rosetta_enabled(),
 
         ("runtime data dir doesn't have spaces",
             " " not in str(RUNTIME_ROOT)),

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -87,7 +87,7 @@ from typing import Iterable, List
 from .. import config, env
 from ..errors import UserError
 from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerTestResultStatus, RunnerUpdateStatus
-from ..util import warn, colored, capture_output, exec_or_return, split_image_name
+from ..util import warn, colored, capture_output, exec_or_return, split_image_name, test_rosetta_enabled
 from ..volume import store_volume, NamedVolume
 from ..__version__ import __version__
 
@@ -387,7 +387,12 @@ def test_setup() -> RunnerTestResults:
         ('docker run works',
             test_run()),
         *test_memory_limit(),
-        *test_image_version()
+        *test_image_version(),
+
+        # Rosetta 2 is optional, so convert False (fail) → None (warning)
+        *[(msg, None if status is False else status)
+            for msg, status
+             in test_rosetta_enabled("Rosetta 2 is enabled for faster execution (optional)")],
     ]
 
 


### PR DESCRIPTION
When on macOS on aarch64 hardware, the Conda runtime currently requires Rosetta.  The Docker runtime does not require it, but can benefit from it because our aarch64 image isn't totally free of x86_64 code (yet?), so emulation is required and Rosetta is faster than QEMU.

The standalone installer still checks for Rosetta as we previously didn't produce aarch64 standalone binaries¹, but that check will be made conditional on Nextstrain CLI version in a subsequent commit² after the first release of aarch64 support and these new Rosetta checks.

¹ <https://github.com/nextstrain/cli/pull/357>
² <https://github.com/nextstrain/cli/pull/358>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
