### PR TITLE
doc: Update cross-ref to a main docs project page that moved

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,8 +18,8 @@ computing platforms, such as
 
 .. note::
     If you're unfamiliar with Nextstrain builds, you may want to follow our
-    :doc:`docs:tutorials/running-a-workflow` tutorial first and then come back
-    here.
+    :doc:`docs:tutorials/running-a-phylogenetic-workflow` tutorial first and
+    then come back here.
 
 
 Table of Contents


### PR DESCRIPTION
<https://github.com/nextstrain/docs.nextstrain.org/commit/cb76eebaa60a0a59d8549be264c9260e12254a25>

Fixes CI errors.  Note that the link was never broken for the already-rendered live docs because the move came with redirects from the old target.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
