### PR TITLE
runner: Support NEXTSTRAIN_RUNTIME_ENVDIRS as an alternative to --envdir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,15 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* Commands which utilize a runtime—`nextstrain build`, `nextstrain shell`, and
+  `nextstrain view`—now support specifying envdirs to forward into the runtime
+  environment by setting `NEXTSTRAIN_RUNTIME_ENVDIRS` to a `:`-separated (`;`
+  on Windows) list of paths.  This is in addition to the existing support for
+  specifying one or more `--envdir` options.
+  ([#365](https://github.com/nextstrain/cli/pull/365))
+
 
 # 8.2.0 (6 February 2024)
 

--- a/doc/commands/build.rst
+++ b/doc/commands/build.rst
@@ -145,7 +145,7 @@ Options shared by all runtimes.
 
 .. option:: --envdir <path>
 
-    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. See the description of :option:`--env` for more details. 
+    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. Envdirs may also be specified by setting ``NEXTSTRAIN_RUNTIME_ENVDIRS`` in the environment to a ``:``-separated list of paths. See the description of :option:`--env` for more details. 
 
 development options
 ===================

--- a/doc/commands/shell.rst
+++ b/doc/commands/shell.rst
@@ -74,7 +74,7 @@ Options shared by all runtimes.
 
 .. option:: --envdir <path>
 
-    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. See the description of :option:`--env` for more details. 
+    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. Envdirs may also be specified by setting ``NEXTSTRAIN_RUNTIME_ENVDIRS`` in the environment to a ``:``-separated list of paths. See the description of :option:`--env` for more details. 
 
 development options
 ===================

--- a/doc/commands/view.rst
+++ b/doc/commands/view.rst
@@ -136,7 +136,7 @@ Options shared by all runtimes.
 
 .. option:: --envdir <path>
 
-    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. See the description of :option:`--env` for more details. 
+    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. Envdirs may also be specified by setting ``NEXTSTRAIN_RUNTIME_ENVDIRS`` in the environment to a ``:``-separated list of paths. See the description of :option:`--env` for more details. 
 
 development options
 ===================


### PR DESCRIPTION
Motivated by some of our automation's desire to pass a set of env vars into the runtime without having to munge a user-provided `nextstrain build` invocation.¹

¹ <https://github.com/nextstrain/private/issues/96#issuecomment-2046243636>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
