### PR TITLE
Officially support Python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -240,7 +241,8 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          # XXX TODO: Add 3.11 here once supported by Augur: https://github.com/nextstrain/augur/issues/1334
+          # XXX TODO: Add 3.11 here once supported by bioconda: https://github.com/nextstrain/augur/issues/1334
+          # XXX TODO: Add 3.12 here once supported by bioconda: https://github.com/nextstrain/augur/issues/1334
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,16 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+This release adds support for Python version 3.12.
+([#TBD](https://github.com/nextstrain/cli/pull/TBD))
+
+Note that this Python version support only matters if you're installing
+Nextstrain CLI from PyPI or Bioconda
+([c.f.](https://docs.nextstrain.org/projects/cli/en/8.3.0/installation/)).  It
+does not apply if you're installing Nextstrain CLI using the standalone
+installation method we recommend in the [Nextstrain installation
+documentation](https://docs.nextstrain.org/page/install.html).  In that case, a
+supported Python version is always bundled with `nextstrain`.
 
 # 8.3.0 (30 April 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 
     # Install a "nextstrain" program which calls nextstrain.cli.__main__.main()
@@ -145,8 +146,7 @@ setup(
             "types-botocore",
             "types-docutils",
             "types-setuptools",
-            "types-requests; python_version != '3.6'",
-            "types-requests <=2.28.11.12; python_version == '3.6'",
+            "types-requests",
         ],
     },
 )


### PR DESCRIPTION
## Description of proposed changes

- Officially support Python 3.12
- Remove setup.py code irrelevant since 3.6/3.7 were dropped in https://github.com/nextstrain/cli/pull/327

## Related issue(s)

- Mirrors #327 

## Checklist

- [x] Checks pass
- [x] Changelog edited

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
