### PR TITLE
Python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -240,7 +241,8 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-          # XXX TODO: Add 3.11 here once supported by Augur: https://github.com/nextstrain/augur/issues/1334
+          # XXX TODO: Add 3.11 here once supported by bioconda: https://github.com/nextstrain/augur/issues/1334
+          # XXX TODO: Add 3.12 here once supported by bioconda: https://github.com/nextstrain/augur/issues/1334
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,16 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+This release adds explicit (i.e. tested) support for Python version 3.12.
+([#369](https://github.com/nextstrain/cli/pull/369))
+
+Note that this Python version support only matters if you're installing
+Nextstrain CLI from PyPI or Bioconda
+([c.f.](https://docs.nextstrain.org/projects/cli/en/__NEXT__/installation/)).  It
+does not apply if you're installing Nextstrain CLI using the standalone
+installation method we recommend in the [Nextstrain installation
+documentation](https://docs.nextstrain.org/page/install.html).  In that case, a
+supported Python version is always bundled with `nextstrain`.
 
 # 8.3.0 (30 April 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -145,8 +145,7 @@ setup(
             "types-botocore",
             "types-docutils",
             "types-setuptools",
-            "types-requests; python_version != '3.6'",
-            "types-requests <=2.28.11.12; python_version == '3.6'",
+            "types-requests",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 
     # Install a "nextstrain" program which calls nextstrain.cli.__main__.main()


### PR DESCRIPTION
See commits. Based on #368 but [with fix ups](https://github.com/nextstrain/cli/compare/py311..python-3.12) I'd noted there in review. (I couldn't bring myself to push 3.12 support to a branch named `py311`, so I pushed a new branch.)


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
