### PR TITLE
build: Add `--exclude-from-upload` and `--exclude-from-download` options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,15 @@ installation method we recommend in the [Nextstrain installation
 documentation](https://docs.nextstrain.org/page/install.html).  In that case, a
 supported Python version is always bundled with `nextstrain`.
 
+## Features
+
+* `nextstrain build` now supports two new options when using the AWS Batch
+  runtime: [`--exclude-from-upload`][] and [`--exclude-from-download`][].  The
+  former is useful for avoiding the upload of large, ancillary files not needed
+  by the build.  The latter exists to parallel the former and make it easier to
+  exclude files from both upload and download.
+  ([#370](https://github.com/nextstrain/cli/pull/370))
+
 ## Improvements
 
 * The Conda runtime now uses Micromamba 1.5.8 (upgraded from 1.1.0) to manage
@@ -31,6 +40,19 @@ supported Python version is always bundled with `nextstrain`.
   index files which speeds up `nextstrain setup` and `nextstrain update` for
   the Conda runtime.
   ([#367](https://github.com/nextstrain/cli/pull/367))
+
+## Bug fixes
+
+* The [`--download`][] option of `nextstrain build` now supports passing _only_
+  negated patterns (e.g. `!…` and `!(…)`).  All files which _don't_ match the
+  negated patterns will be downloaded.  Previously, no files were downloaded
+  unless at least one positive pattern was given.
+  ([#370](https://github.com/nextstrain/cli/pull/370))
+
+
+[`--exclude-from-upload`]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/build/#cmdoption-nextstrain-build-exclude-from-upload
+[`--exclude-from-download`]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/build/#cmdoption-nextstrain-build-exclude-from-download
+[`--download`]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/build/#cmdoption-nextstrain-build-download
 
 
 # 8.3.0 (30 April 2024)

--- a/doc/commands/build.rst
+++ b/doc/commands/build.rst
@@ -97,12 +97,66 @@ options
     wildcards (``**``), extended globbing (``@(…)``, ``+(…)``, etc.),
     and negation (``!…``).
 
+    Patterns should be relative to the build directory.
+
 
 
 
 .. option:: --no-download
 
     Do not download any files from the remote build when it completes. Currently only supported when also using :option:`--aws-batch`.
+
+.. option:: --exclude-from-download <pattern>
+
+    Exclude files matching ``<pattern>`` from being downloaded from
+    the remote build.  Equivalent to passing a negated pattern to
+    :option:`--download`.  That is, the following are equivalent::
+
+        --exclude-from-download 'xyz'
+        --download '!xyz'
+
+    Refer to :option:`--download` for usage details, but note that this
+    option doesn't support already-negated patterns (e.g. ``!…`` or
+    ``!(…)``).
+
+    This option exists to parallel :option:`--exclude-from-upload`.
+
+
+
+
+.. option:: --exclude-from-upload <pattern>
+
+    Exclude files matching ``<pattern>`` from being uploaded as part of
+    the remote build.  Shell-style advanced globbing is supported, but
+    be sure to escape wildcards or quote the whole pattern so your
+    shell doesn't expand them.  May be passed more than once.
+    Currently only supported when also using :option:`--aws-batch`.
+    Default is to upload the entire pathogen build directory (except
+    for some ancillary files which are always excluded).
+
+    Note that files excluded from upload may still be downloaded from
+    the remote build, e.g. if they're created by it, and if downloaded
+    will overwrite the local files.  Use :option:`--no-download` to
+    avoid downloading any files, or :option:`--exclude-from-download`
+    to avoid downloading specific files, e.g.::
+
+        --exclude-from-upload 'results/**' \
+        --exclude-from-download 'results/**'
+
+    Your shell's brace expansion can also be used to shorten this, e.g.::
+
+        --exclude-from-{up,down}load='results/**'
+
+    Besides basic glob features like single-part wildcards (``*``),
+    character classes (``[…]``), and brace expansion (``{…, …}``),
+    several advanced globbing features are also supported: multi-part
+    wildcards (``**``), extended globbing (``@(…)``, ``+(…)``, etc.),
+    and negation (``!…``).
+
+    Patterns should be relative to the build directory.
+
+
+
 
 .. option:: --no-logs
 

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -104,6 +104,8 @@ def register_parser(subparser):
             wildcards (``**``), extended globbing (``@(…)``, ``+(…)``, etc.),
             and negation (``!…``).
 
+            Patterns should be relative to the build directory.
+
             {SKIP_AUTO_DEFAULT_IN_HELP}
             """),
         default = True,
@@ -116,6 +118,66 @@ def register_parser(subparser):
                   f"{SKIP_AUTO_DEFAULT_IN_HELP}",
         dest   = "download",
         action = "store_false")
+
+    parser.add_argument(
+        "--exclude-from-download",
+        metavar = "<pattern>",
+        help    = dedent(f"""\
+            Exclude files matching ``<pattern>`` from being downloaded from
+            the remote build.  Equivalent to passing a negated pattern to
+            :option:`--download`.  That is, the following are equivalent::
+
+                --exclude-from-download 'xyz'
+                --download '!xyz'
+
+            Refer to :option:`--download` for usage details, but note that this
+            option doesn't support already-negated patterns (e.g. ``!…`` or
+            ``!(…)``).
+
+            This option exists to parallel :option:`--exclude-from-upload`.
+
+            {SKIP_AUTO_DEFAULT_IN_HELP}
+            """),
+        dest    = "download",
+        type    = lambda pattern: f"!{pattern}",
+        action  = AppendOverwriteDefault)
+
+    parser.add_argument(
+        "--exclude-from-upload",
+        metavar = "<pattern>",
+        help    = dedent(f"""\
+            Exclude files matching ``<pattern>`` from being uploaded as part of
+            the remote build.  Shell-style advanced globbing is supported, but
+            be sure to escape wildcards or quote the whole pattern so your
+            shell doesn't expand them.  May be passed more than once.
+            Currently only supported when also using :option:`--aws-batch`.
+            Default is to upload the entire pathogen build directory (except
+            for some ancillary files which are always excluded).
+
+            Note that files excluded from upload may still be downloaded from
+            the remote build, e.g. if they're created by it, and if downloaded
+            will overwrite the local files.  Use :option:`--no-download` to
+            avoid downloading any files, or :option:`--exclude-from-download`
+            to avoid downloading specific files, e.g.::
+
+                --exclude-from-upload 'results/**' \\
+                --exclude-from-download 'results/**'
+
+            Your shell's brace expansion can also be used to shorten this, e.g.::
+
+                --exclude-from-{{up,down}}load='results/**'
+
+            Besides basic glob features like single-part wildcards (``*``),
+            character classes (``[…]``), and brace expansion (``{{…, …}}``),
+            several advanced globbing features are also supported: multi-part
+            wildcards (``**``), extended globbing (``@(…)``, ``+(…)``, etc.),
+            and negation (``!…``).
+
+            Patterns should be relative to the build directory.
+
+            {SKIP_AUTO_DEFAULT_IN_HELP}
+            """),
+        action  = "append")
 
     # A --logs option doesn't make much sense right now for most of our
     # runtimes, but I can see how it might in the future.  So we're ready if

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -213,7 +213,7 @@ def run(opts, argv, working_volume = None, extra_env: Env = {}, cpus: int = None
         print_stage("Uploading %s to S3" % local_workdir)
 
         bucket = s3.bucket(opts.s3_bucket)
-        remote_workdir = s3.upload_workdir(local_workdir, bucket, run_id)
+        remote_workdir = s3.upload_workdir(local_workdir, bucket, run_id, opts.exclude_from_upload)
 
         print("uploaded:", s3.object_url(remote_workdir))
 

--- a/tests/command-build.py
+++ b/tests/command-build.py
@@ -1,0 +1,29 @@
+from nextstrain.cli import make_parser
+
+
+def pytest_build_download_options():
+    parser = make_parser()
+
+    opts = parser.parse_args(["build", "."])
+    assert opts.download is True
+
+    opts = parser.parse_args(["build", "--no-download", "."])
+    assert opts.download is False
+
+    opts = parser.parse_args(["build", "--download", "x", "."])
+    assert opts.download == ["x"]
+
+    opts = parser.parse_args(["build", "--download", "x", "--download", "y", "."])
+    assert opts.download == ["x", "y"]
+
+    opts = parser.parse_args(["build", "--exclude-from-download", "z", "."])
+    assert opts.download == ["!z"]
+
+    opts = parser.parse_args(["build", "--exclude-from-download", "z", "--exclude-from-download", "a", "."])
+    assert opts.download == ["!z", "!a"]
+
+    opts = parser.parse_args(["build", "--download", "y", "--exclude-from-download", "z", "."])
+    assert opts.download == ["y", "!z"]
+
+    opts = parser.parse_args(["build", "--download", "y", "--download", "!z", "."])
+    assert opts.download == ["y", "!z"]


### PR DESCRIPTION
Excluding files from upload is very handy for ad-hoc skipping of large ancillary files or previous output files in the build directory that the user wants to ignore for the remote build on AWS Batch (i.e. to start it "fresh").  Existing workarounds for the lack of an exclusion mechanism include git worktrees to obtain a clean state and moving files or directories temporarily out of the build directory.

A future improvement would be adding support to also specify these patterns via a file, which can then be checked in to a build repo and shared by all users.

As a broader improvement, I'd like to design away this issue by separating out the workflow-as-program (rules, code, etc.) from the workflow-as-state (config, inputs, outputs, etc.).  This comes out of several other goals, but would apply to this "excluded files" need too. For example, instead of relying on the implicit state combined with the code like now in a single build directory, we'd instead explicitly pass an empty starting state separate from the workflow program.

This change includes a small bug fix for --download to allow _only_ negated patterns.

Resolves: <https://github.com/nextstrain/cli/issues/219>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
