### PR TITLE
Remove/replace macos-11 jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             exe: nextstrain
 
-          - os: macos-11
+          - os: macos-12
             target: x86_64-apple-darwin
             exe: nextstrain
 
@@ -285,7 +285,6 @@ jobs:
         include:
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
-          - { os: macos-11,     target: x86_64-apple-darwin }
           - { os: macos-12,     target: x86_64-apple-darwin }
           - { os: macos-14,     target: aarch64-apple-darwin }
           - { os: windows-2019, target: x86_64-pc-windows-msvc }

--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -37,7 +37,6 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-11
           - macos-12
           - macos-14      # (aarch64)
           - windows-2019


### PR DESCRIPTION
## Description of proposed changes

GH Action has removed macos-11 on 28 June 2024.¹

Drop it from two lists and replace it with macos-12 in one list to represent the oldest available macOS runner to build for x86_64-apple-darwin.

¹ <https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal>

## Related issue(s)

- Resolves #375

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
