### PR TITLE
Use osx-arm64 packages on Apple silicon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* The Conda runtime no longer requires Rosetta 2 for macOS running on aarch64
+  (aka arm64, Apple Silicon, M1/M2) hardware.  This improves performance when
+  using the runtime.
 
 # 9.0.0 (24 March 2025)
 

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -87,7 +87,7 @@ from urllib.parse import urljoin, quote as urlquote
 from ..errors import InternalError
 from ..paths import RUNTIMES
 from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
-from ..util import capture_output, colored, exec_or_return, runner_tests_ok, test_rosetta_enabled, warn
+from ..util import capture_output, colored, exec_or_return, runner_tests_ok, warn
 
 
 RUNTIME_ROOT = RUNTIMES / "conda/"
@@ -453,9 +453,6 @@ def test_support() -> RunnerTestResults:
         if system == "Linux":
             return machine == "x86_64"
 
-        # Note even on arm64 (e.g. aarch64, Apple Silicon M1) we use x86_64
-        # binaries because of current ecosystem compatibility, but Rosetta will
-        # make it work.
         elif system == "Darwin":
             return machine in {"x86_64", "arm64"}
 
@@ -466,8 +463,6 @@ def test_support() -> RunnerTestResults:
 
     yield ('operating system is supported',
             supported_os())
-
-    yield from test_rosetta_enabled()
 
     yield ("runtime data dir doesn't have spaces",
             " " not in str(RUNTIME_ROOT))
@@ -605,9 +600,10 @@ def package_distribution(channel: str, package: str, version: str = None, label:
 
     if (system, machine) == ("Linux", "x86_64"):
         subdir = "linux-64"
-    elif (system, machine) in {("Darwin", "x86_64"), ("Darwin", "arm64")}:
-        # Use the x86 arch even on arm (https://docs.nextstrain.org/en/latest/reference/faq.html#why-intel-miniconda-installer-on-apple-silicon)
+    elif (system, machine) == ("Darwin", "x86_64"):
         subdir = "osx-64"
+    elif (system, machine) == ("Darwin", "arm64"):
+        subdir = "osx-arm64"
     else:
         raise InternalError(f"Unsupported system/machine: {system}/{machine}")
 


### PR DESCRIPTION
## Description of proposed changes

Previously the osx-64 packages were used because osx-arm64 was not supported. Rosetta 2 is no longer required for the conda runner on Apple silicon.

## Checklist

- [x] Merge https://github.com/nextstrain/conda-base/pull/80
- [x] Test locally: run a draft ebola workflow using this runtime
- [x] Test locally: auto-update works as expected

    ```
    NEXTSTRAIN_CONDA_BASE_PACKAGE="nextstrain-base ==20250226T220403Z" ~/.nextstrain/cli-standalone/nextstrain setup conda --force
    ./devel/venv-run nextstrain update
    ```

- [ ] Post-merge: merge https://github.com/nextstrain/docs.nextstrain.org/pull/246

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
