### PR TITLE
dev: Upgrade setup-miniconda action from v2 → v3

### DIFF
--- a/.github/actions/setup-integration-tests/action.yaml
+++ b/.github/actions/setup-integration-tests/action.yaml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ inputs.python-version }}
         miniforge-variant: Mambaforge


### PR DESCRIPTION
The latest version will now use Conda's osx-arm64 channel on macOS when available.  As it seems we're encountering issues with osx-64 packages on arm64 hardware¹, let's see if this switch helps avoid those issues.

¹ <https://github.com/nextstrain/cli/issues/382>

Resolves #386 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
