### PR TITLE
Anchor regexes and escape potential metachars [#388]

### DIFF
--- a/doc/aws-batch.md
+++ b/doc/aws-batch.md
@@ -348,7 +348,7 @@ each run.  You must adjust the [log retention policy][] for the
 continue to pay for their storage.  You may use a shorter (or longer) lifetime,
 but Amazon's prorated billing uses a minimum duration of one month.
 
-[log retention policy]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention
+[log retention policy]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SttingLogRetention
 
 
 ### Disk space for your jobs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,17 +75,22 @@ intersphinx_mapping = {
 
 # -- Linkchecking ------------------------------------------------------------
 
+## NOTE: for both sets of regular expressions that follow, the
+## underlying linkchecker code uses `re.match()` to apply them to URLs
+## — so there's already an implicit "only at the beginning of a
+## string" matching happening, and something like a plain `r'google'`
+## regular expression will _NOT_ match all google.com URLs.
 linkcheck_ignore = [
      # we have links to localhost for explanatory purposes; obviously
      # they will never work in the linkchecker
-     r'http://127.0.0.1:\d+',
-     r'http://localhost:\d+',
+     r'^http://127\.0\.0\.1:\d+',
+     r'^http://localhost:\d+',
 ]
 linkcheck_anchors_ignore_for_url = [
      # Github uses anchor-looking links for highlighting lines but
      # handles the actual resolution with Javascript, so skip anchor
      # checks for Github URLs:
-     r'https://github.com',
-     r'https://console.aws.amazon.com/batch/home',
-     r'https://console.aws.amazon.com/ec2/v2/home',
+     r'^https://github\.com',
+     r'^https://console\.aws\.amazon\.com/batch/home',
+     r'^https://console\.aws\.amazon\.com/ec2/v2/home',
 ]


### PR DESCRIPTION
Per post-merge feedback.

Also add note that the underlying code in the linkchecker uses `re.match()` to evaluate the regular expression, so there's already an implicit start of string anchor in effect, and something like `r'google'` will _NOT_ match anything.
