### PR TITLE
remote.nextstrain_dot_org: Include an explicit origin in error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,15 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* The suggested commands to run (i.e. potential solutions) in expected errors
+  from `nextstrain remote` now explicitly include the remote origin to avoid
+  being incorrect or misleading for origins other than nextstrain.org.  For
+  example, if the error message suggested running `nextstrain login`, it now
+  suggests `nextstrain login https://nextstrain.org`.
+  ([#391](https://github.com/nextstrain/cli/pull/391))
+
 
 # 8.5.1 (31 July 2024)
 


### PR DESCRIPTION
Otherwise, for remote origins other than the default of nextstrain.org, the error messages suggest incorrect/misleading possible solutions in the form of commands to run.

Motivated by @jameshadfield's comments in Slack.¹

¹ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1723760025178909?thread_ts=1723701856.612259&cid=C01LCTT7JNN>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
