### PR TITLE
runner.conda: Ignore newly failing type check for tarfile.open()

### DIFF
--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -217,7 +217,7 @@ def setup_micromamba(dry_run: bool = False, force: bool = False) -> bool:
         assert content_type == "application/x-tar", \
             f"unknown content-type for micromamba dist: {content_type}"
 
-        with tarfile.open(fileobj = response.raw, mode = "r|*") as tar:
+        with tarfile.open(fileobj = response.raw, mode = "r|*") as tar: # type: ignore
             # Ignore archive members starting with "/" and or including ".." parts,
             # as these can be used (maliciously or accidentally) to overwrite
             # unintended files (e.g. files outside of MICROMAMBA_ROOT).


### PR DESCRIPTION
This started failing recently with newer typeshed stubs for tarfile.open() (and/or newer stubs for requests.Response?).

mypy fails with:

    nextstrain/cli/runner/conda.py:220: error: Argument "fileobj" to "open" has incompatible type "Union[HTTPResponse, Any]"; expected "Optional[IO[bytes]]"

and pyright with:

    nextstrain/cli/runner/conda.py:220:14 - error: No overloads for "open" match the provided arguments (reportCallIssue)
    nextstrain/cli/runner/conda.py:220:58 - error: Argument of type "Literal['r|*']" cannot be assigned to parameter "mode" of type "_FileCreationModes" in function "open"
      Type "Literal['r|*']" is not assignable to type "_FileCreationModes"
        "Literal['r|*']" is not assignable to type "Literal['a']"
        "Literal['r|*']" is not assignable to type "Literal['w']"
        "Literal['r|*']" is not assignable to type "Literal['x']" (reportArgumentType)

I'm guessing the difference is because they match the different overloads of tarfile.open().

I dug into it a little¹, but the stubs here seem a bit scattershot at the moment so I stopped and went with an ignore. An alternative fix is casting response.raw to BinaryIO, but that seemed uglier and worse than an ignore.

¹ See <https://github.com/python/typeshed/pull/12117> (implicated) and <https://github.com/python/typeshed/pull/12181> (open, may fix?) and <https://github.com/python/typeshed/issues/12182> (open, may fix?)


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
