### PR TITLE
devel/pyoxidizer: Correctly locate just one already-downloaded PyOxidizer binary

### DIFF
--- a/devel/pyoxidizer
+++ b/devel/pyoxidizer
@@ -29,7 +29,7 @@ main() {
 
 locate() {
     # Locate existing local copy of pyoxidizer.
-    echo "$devel"/pyoxidizer-[0-9]*_"$(platform-machine)"?(.exe) | head -n1
+    printf '%s\n' "$devel"/pyoxidizer-[0-9]*_"$(platform-machine)"?(.exe) | sort --reverse --version-sort | head -n1
 }
 
 download() {


### PR DESCRIPTION
Taking the first line never worked as intended, as the input from echo was never multi-line but space-separated words.  orz

Reverse version sort for good measure to use the newest version instead of oldest if we have more than one (which was how I ran into this bug in the first place).