### PR TITLE
dev: Stop using Mambaforge in CI; the Miniforge installer is now equivalent

### DIFF
--- a/.github/actions/setup-integration-tests/action.yaml
+++ b/.github/actions/setup-integration-tests/action.yaml
@@ -25,7 +25,7 @@ runs:
     - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ inputs.python-version }}
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         channels: conda-forge,bioconda
 
     - run: cat ~/.profile || true


### PR DESCRIPTION
Scheduled CI runs today failed¹ due to a Mambaforge brownout ahead of its removal in January 2025; it was deprecated in late July 2024.²

¹ <https://github.com/nextstrain/cli/actions/runs/11130647037/job/30930449798#step:3:135>
² <https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
