### PR TITLE
dev: Silence new complaint from Mypy in CI

### DIFF
--- a/nextstrain/cli/rst/sphinx.py
+++ b/nextstrain/cli/rst/sphinx.py
@@ -426,7 +426,7 @@ def my_wrap(text: str, width: int = MAXWIDTH, **kwargs: Any) -> List[str]:
 class TextWriter(writers.Writer):
     supported = ('text',)
     settings_spec = ('No options here.', '', ())
-    settings_defaults: Dict = {}
+    settings_defaults = {}
 
     output: str = None
 


### PR DESCRIPTION
A new version of either Mypy or Docutils resulted in this new error:

    nextstrain/cli/rst/sphinx.py:429: error: Cannot override class variable (previously declared on base class "SettingsSpec") with instance variable  [misc]

I don't quite understand why Mypy thinks "settings_defaults" here is an instance variable since it's declared in the class body, but removing the type declaration is enough to appease it (presumably because it's no longer checking it).  The type declaration is unnecessary anyway in this bit of code.

Note that we don't even check this file with Pyright.  It's mostly third-party code extracted from Sphinx, and it was going to be too much work to make it pass our type checking.  Mypy was left enabled for it because it passed with only minor fixups, and that's still the case, but it's also probably true that Mypy is not doing very much for us in this file anyway.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
