### PR TITLE
dev: Update GitHub runners used by CI

### DIFF
--- a/.github/actions/setup-integration-tests/action.yaml
+++ b/.github/actions/setup-integration-tests/action.yaml
@@ -91,7 +91,11 @@ runs:
         url="$(
           curl -fsSL --proto '=https' -H "Authorization: Bearer $GITHUB_TOKEN" \
             "https://api.github.com/repos/sylabs/singularity/releases?per_page=100" \
-              | jq -r 'map(select(.tag_name | startswith("v3."))) | .[0].assets | map(select(.name | endswith("\(env.UBUNTU_CODENAME)_amd64.deb"))) | .[0].browser_download_url')"
+              | jq -r '
+                    map(select(.tag_name | startswith("v3.")))
+                  | .[0].assets
+                  |    (map(select(.name | endswith("\(env.UBUNTU_CODENAME)_amd64.deb"))) | .[0].browser_download_url)
+                    // (map(select(.name | endswith("jammy_amd64.deb")))                  | .[0].browser_download_url)')"
 
         curl -fsSL --proto '=https' "$url" > singularity.deb
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             exe: nextstrain
 
-          - os: macos-12
+          - os: macos-13
             target: x86_64-apple-darwin
             exe: nextstrain
 
@@ -285,8 +285,12 @@ jobs:
         include:
           - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
-          - { os: macos-12,     target: x86_64-apple-darwin }
+          - { os: ubuntu-24.04, target: x86_64-unknown-linux-gnu }
+          - { os: macos-13,     target: x86_64-apple-darwin }
+          - { os: macos-14,     target: x86_64-apple-darwin }
+          - { os: macos-15,     target: x86_64-apple-darwin }
           - { os: macos-14,     target: aarch64-apple-darwin }
+          - { os: macos-15,     target: aarch64-apple-darwin }
           - { os: windows-2019, target: x86_64-pc-windows-msvc }
           - { os: windows-2022, target: x86_64-pc-windows-msvc }
 

--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -37,8 +37,10 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-12
+          - ubuntu-24.04
+          - macos-13
           - macos-14      # (aarch64)
+          - macos-15      # (aarch64)
           - windows-2019
           - windows-2022
 


### PR DESCRIPTION
macOS 12 was deprecated in August and will be removed by December.¹  I moved the build and test jobs to the next oldest version, macOS 13.

Ubuntu 24.04 was released in late September,² so test on it.

macOS 15 was released for beta in late September,² so test on it too.

Test the x86_64 binary on macOS 14 and 15 too since it should work with Rosetta.  I'm not sure why it wasn't tested on macOS 14 previously; maybe just an oversight?

¹ <https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/>
² <https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
