### PR TITLE
Workflows-as-programs: `nextstrain run`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,43 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+This release is the first to include initial support for setting up and running
+pathogen workflows without the co-mingling of our workflow source code with
+your inputs and outputs (e.g. your `config.yaml`, `data/`, and `results/`) and
+without needing to download source code or use Git yourself.  Pathogens are
+first set up with `nextstrain setup` and their workflows may then be run using
+`nextstrain run`, a new command in this release.  These features are part of
+our broader "workflows as programs" endeavor.
+
+## Features
+
+* A new command, [`nextstrain run`][], for running pathogen workflows in a more
+  managed way as part of our broader "workflows as programs" endeavor.
+
+  Workflows (e.g. `ingest`, `phylogenetic`) for a pathogen are run in a
+  Nextstrain runtime with config and input (e.g. `config.yaml`, `data/`) from
+  an analysis directory you provide and outputs (e.g. `results/`) written to
+  that same directory.
+
+  Pathogens (e.g. `measles`) are initially set up using `nextstrain setup` and
+  can be updated over time as desired using `nextstrain update`.  Multiple
+  versions of a pathogen may be set up and run independently without conflict,
+  allowing for comparisons of output across versions.  The same pathogen
+  workflow may also be concurrently run multiple times with separate analysis
+  directories (i.e. different configs, input data, etc.) without conflict,
+  allowing for independent outputs and analyses.  Set up pathogens and their
+  versions are listed by `nextstrain version --pathogens`.
+
+  Compared to `nextstrain build`, this new `nextstrain run` command is a
+  higher-level interface to running pathogen workflows that does not require
+  knowledge of Git or management of pathogen repositories and source code.  For
+  now, the `nextstrain build` command remains more suitable for active
+  authorship and development of workflows.
+  ([#407][])
+
+[#407]: https://github.com/nextstrain/cli/pull/407
+[`nextstrain run`]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/run/
+
 
 # 9.0.0 (24 March 2025)
 

--- a/doc/commands/index.rst
+++ b/doc/commands/index.rst
@@ -14,7 +14,7 @@ nextstrain
 
 .. code-block:: none
 
-    usage: nextstrain [-h] {build,view,deploy,remote,shell,update,setup,check-setup,login,logout,whoami,version,init-shell,authorization,debugger} ...
+    usage: nextstrain [-h] {run,build,view,deploy,remote,shell,update,setup,check-setup,login,logout,whoami,version,init-shell,authorization,debugger} ...
 
 
 Nextstrain command-line interface (CLI)
@@ -41,6 +41,10 @@ commands
 
 
 
+.. option:: run
+
+    Run pathogen workflow. See :doc:`/commands/run`.
+
 .. option:: build
 
     Run pathogen build. See :doc:`/commands/build`.
@@ -63,11 +67,11 @@ commands
 
 .. option:: update
 
-    Update a runtime. See :doc:`/commands/update`.
+    Update a pathogen or runtime. See :doc:`/commands/update`.
 
 .. option:: setup
 
-    Set up a runtime. See :doc:`/commands/setup`.
+    Set up a pathogen or runtime. See :doc:`/commands/setup`.
 
 .. option:: check-setup
 

--- a/doc/commands/run.rst
+++ b/doc/commands/run.rst
@@ -1,0 +1,255 @@
+.. default-role:: literal
+
+.. role:: command-reference(ref)
+
+.. program:: nextstrain run
+
+.. _nextstrain run:
+
+==============
+nextstrain run
+==============
+
+.. code-block:: none
+
+    usage: nextstrain run [options] <pathogen-name>[@<version>] <workflow-name> <analysis-directory> [<target> [<target> [...]]]
+           nextstrain run --help
+
+
+Runs a pathogen workflow in a Nextstrain runtime with config and input from an
+analysis directory and outputs written to that same directory.
+
+This command focuses on the routine running of existing pathogen workflows
+(mainly provided by Nextstrain) using your own configuration, data, and other
+supported customizations.  Pathogens are initially set up using `nextstrain
+setup` and can be updated over time as desired using `nextstrain update`.
+Multiple versions of a pathogen may be set up and run independently without
+conflict, allowing for comparisons of output across versions.  The same
+pathogen workflow may also be concurrently run multiple times with separate
+analysis directories (i.e. different configs, input data, etc.) without
+conflict, allowing for independent outputs and analyses.
+
+Compared to `nextstrain build`, this command is a higher-level interface to
+running pathogen workflows that does not require knowledge of Git or management
+of pathogen repositories and source code.  For now, the `nextstrain build`
+command remains more suitable for active authorship and development of
+workflows.
+
+All Nextstrain runtimes are supported.  For AWS Batch, all runs will detach
+after submission and `nextstrain build` must be used to further monitor or
+manage the run and download results after completion.
+
+positional arguments
+====================
+
+
+
+.. option:: <pathogen-name>[@<version>]
+
+    The name (and optionally, version) of a previously set up pathogen.
+    See :command-reference:`nextstrain setup`.  If no version is
+    specified, then the default version (if any) will be used.
+
+    Required.
+
+.. option:: <workflow-name>
+
+    The name of a workflow for the given pathogen, e.g. typically
+    ``ingest``, ``phylogenetic``, or ``nextclade``.
+
+    Available workflows may vary per pathogen (and possibly between
+    pathogen version).  Some pathogens may provide multiple variants or
+    base configurations of a top-level workflow, e.g. as in
+    ``phylogenetic/mpxv`` and ``phylogenetic/hmpxv1``.  Refer to the
+    pathogen's own documentation for valid workflow names.
+
+    Workflow names conventionally correspond directly to directory
+    paths in the pathogen source, but this may not always be the case.
+
+    Required.
+
+.. option:: <analysis-directory>
+
+    The path to your analysis directory.  The workflow uses this as its
+    working directory for all local inputs and outputs, including
+    config files, input data files, resulting output data files, log
+    files, etc.
+
+    We recommend keeping your config files and static input files (e.g.
+    reference sequences, inclusion/exclusion lists, annotations, etc.)
+    in a version control system, such as Git, so you can keep track of
+    changes over time and recover previous versions.  When using
+    version control, dynamic inputs (e.g. downloaded input filefs) and
+    outputs (e.g. resulting data files, log files, etc.) should
+    generally be marked as ignored/excluded from tracking, such as via
+    :file:`.gitignore` for Git.
+
+    An empty directory will be automatically created if the given path
+    does not exist but its parent directory does.
+
+    Required.
+
+.. option:: <target>
+
+    One or more workflow targets.  A target is either a file path
+    (relative to :option:`<analysis-directory>`) produced by the
+    workflow or the name of a workflow rule or step.
+
+    Available targets will vary per pathogen (and between versions of
+    pathogens).  Refer to the pathogen's own documentation for valid
+    targets.
+
+    Optional.
+
+options
+=======
+
+
+
+.. option:: --force
+
+    Force a rerun of the whole workflow even if everything seems up-to-date.
+
+.. option:: --cpus <count>
+
+    Number of CPUs/cores/threads/jobs to utilize at once.  Limits containerized (Docker, AWS Batch) workflow runs to this amount.  Informs Snakemake's resource scheduler when applicable.  Informs the AWS Batch instance size selection.  By default, no constraints are placed on how many CPUs are used by a workflow run; workflow runs may use all that are available if they're able to.
+
+.. option:: --memory <quantity>
+
+    Amount of memory to make available to the workflow run.  Units of b, kb, mb, gb, kib, mib, gib are supported.  Limits containerized (Docker, AWS Batch) workflow runs to this amount.  Informs Snakemake's resource scheduler when applicable.  Informs the AWS Batch instance size selection.  
+
+.. option:: --exclude-from-upload <pattern>
+
+    Exclude files matching ``<pattern>`` from being uploaded as part of
+    the remote build.  Shell-style advanced globbing is supported, but
+    be sure to escape wildcards or quote the whole pattern so your
+    shell doesn't expand them.  May be passed more than once.
+    Currently only supported when also using :option:`--aws-batch`.
+    Default is to upload the entire pathogen build directory (except
+    for some ancillary files which are always excluded).
+
+    Note that files excluded from upload may still be downloaded from
+    the remote build, e.g. if they're created by it, and if downloaded
+    will overwrite the local files.  When attaching to the build, use
+    :option:`nextstrain build --no-download` to avoid downloading any
+    files or :option:`nextstrain build --exclude-from-download` to
+    avoid downloading specific files.
+
+    Besides basic glob features like single-part wildcards (``*``),
+    character classes (``[…]``), and brace expansion (``{…, …}``),
+    several advanced globbing features are also supported: multi-part
+    wildcards (``**``), extended globbing (``@(…)``, ``+(…)``, etc.),
+    and negation (``!…``).
+
+    Patterns should be relative to the build directory.
+
+
+
+
+.. option:: --help, -h
+
+    Show a brief help message of common options and exit
+
+.. option:: --help-all
+
+    Show a full help message of all options and exit
+
+runtime selection options
+=========================
+
+Select the Nextstrain runtime to use, if the
+default is not suitable.
+
+.. option:: --docker
+
+    Run commands inside a container image using Docker. (default)
+
+.. option:: --conda
+
+    Run commands with access to a fully-managed Conda environment.
+
+.. option:: --singularity
+
+    Run commands inside a container image using Singularity.
+
+.. option:: --ambient
+
+    Run commands in the ambient environment, outside of any container image or managed environment.
+
+.. option:: --aws-batch
+
+    Run commands remotely on AWS Batch inside the Nextstrain container image.
+
+runtime options
+===============
+
+Options shared by all runtimes.
+
+.. option:: --env <name>[=<value>]
+
+    Set the environment variable ``<name>`` to the value in the current environment (i.e. pass it thru) or to the given ``<value>``. May be specified more than once. Overrides any variables of the same name set via :option:`--envdir`. When this option or :option:`--envdir` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. The "well-known" variables are ``AUGUR_RECURSION_LIMIT``, ``AUGUR_MINIFY_JSON``, ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, ``AWS_SESSION_TOKEN``, ``ID3C_URL``, ``ID3C_USERNAME``, ``ID3C_PASSWORD``, ``RETHINK_HOST``, and ``RETHINK_AUTH_KEY``. Pass those variables explicitly via :option:`--env` or :option:`--envdir` if you need them in combination with other variables. 
+
+.. option:: --envdir <path>
+
+    Set environment variables from the envdir at ``<path>``. May be specified more than once. An envdir is a directory containing files describing environment variables. Each filename is used as the variable name. The first line of the contents of each file is used as the variable value. When this option or :option:`--env` is given, the default behaviour of automatically passing thru several "well-known" variables is disabled. Envdirs may also be specified by setting ``NEXTSTRAIN_RUNTIME_ENVDIRS`` in the environment to a ``:``-separated list of paths. See the description of :option:`--env` for more details. 
+
+development options
+===================
+
+These should generally be unnecessary unless you're developing Nextstrain.
+
+.. option:: --image <image>
+
+    Container image name to use for the Nextstrain runtime (default: nextstrain/base for Docker and AWS Batch, docker://nextstrain/base for Singularity)
+
+.. option:: --augur <dir>
+
+    Replace the image's copy of augur with a local copy
+
+.. option:: --auspice <dir>
+
+    Replace the image's copy of auspice with a local copy
+
+.. option:: --fauna <dir>
+
+    Replace the image's copy of fauna with a local copy
+
+.. option:: --exec <prog>
+
+    Program to run inside the runtime
+
+development options for --docker
+================================
+
+
+
+.. option:: --docker-arg ...
+
+    Additional arguments to pass to `docker run`
+
+development options for --aws-batch
+===================================
+
+See <https://docs.nextstrain.org/projects/cli/page/aws-batch>
+for more information.
+
+.. option:: --aws-batch-job <name>
+
+    Name of the AWS Batch job definition to use
+
+.. option:: --aws-batch-queue <name>
+
+    Name of the AWS Batch job queue to use
+
+.. option:: --aws-batch-s3-bucket <name>
+
+    Name of the AWS S3 bucket to use as shared storage
+
+.. option:: --aws-batch-cpus <count>
+
+    Number of vCPUs to request for job
+
+.. option:: --aws-batch-memory <mebibytes>
+
+    Amount of memory in MiB to request for job
+

--- a/doc/commands/setup.rst
+++ b/doc/commands/setup.rst
@@ -12,15 +12,24 @@ nextstrain setup
 
 .. code-block:: none
 
-    usage: nextstrain setup [-h] [--dry-run] [--force] [--set-default] <runtime>
+    usage: nextstrain setup [--dry-run] [--force] [--set-default] <pathogen-name>[@<version>[=<url>]]
+           nextstrain setup [--dry-run] [--force] [--set-default] <runtime-name>
+           nextstrain setup --help
 
 
-Sets up a Nextstrain runtime for use with `nextstrain build`, `nextstrain
-view`, etc.
+Sets up a Nextstrain pathogen for use with `nextstrain run` or a Nextstrain
+runtime for use with `nextstrain run`, `nextstrain build`, `nextstrain view`,
+etc.
 
-Only the Conda runtime currently supports automated set up, but this command
-may still be used with other runtimes to check an existing (manual) setup and
-set the runtime as the default on success.
+For pathogens, set up involves downloading a specific version of the pathogen's
+Nextstrain workflows.  By convention, this download is from Nextstrain's
+repositories.  More than one version of the same pathogen may be set up and
+used independently.  This can be useful for comparing analyses across workflow
+versions.  A default version can be set.
+
+For runtimes, only the Conda runtime currently supports fully-automated set up,
+but this command may still be used with other runtimes to check an existing
+(manual) setup and set the runtime as the default on success.
 
 Exits with an error code if automated set up fails or if setup checks fail.
 
@@ -29,9 +38,24 @@ positional arguments
 
 
 
-.. option:: <runtime>
+.. option:: <pathogen>|<runtime>
 
-    The Nextstrain runtime to set up. One of {docker, conda, singularity, ambient, aws-batch}.
+    The Nextstrain pathogen or runtime to set up.
+
+    A pathogen is usually the plain name of a Nextstrain-maintained
+    pathogen (e.g. ``measles``), optionally with an ``@<version>``
+    specifier (e.g. ``measles@v42``).  If ``<version>`` is specified in
+    this case, it must be a tag name (i.e. a release name), development
+    branch name, or a development commit id.
+
+    A pathogen may also be fully-specified as ``<name>@<version>=<url>``
+    where ``<name>`` and ``<version>`` in this case are (mostly)
+    arbitrary and ``<url>`` points to a ZIP file containing the
+    pathogen repository contents (e.g.
+    ``https://github.com/nextstrain/measles/zipball/83b446d67fc03de2ce1c72bb1345b4c4eace7231``).
+
+    A runtime is one of {docker, conda, singularity, ambient, aws-batch}.
+
 
 options
 =======
@@ -52,5 +76,5 @@ options
 
 .. option:: --set-default
 
-    Use the runtime as the default if set up is successful.
+    Use this pathogen version or runtime as the default if set up is successful.
 

--- a/doc/commands/update.rst
+++ b/doc/commands/update.rst
@@ -12,14 +12,17 @@ nextstrain update
 
 .. code-block:: none
 
-    usage: nextstrain update [-h] [<runtime>]
+    usage: nextstrain update [<pathogen-name>[@<version>] | <runtime-name> […]]
+           nextstrain update
+           nextstrain update --help
 
 
-Updates a Nextstrain runtime to the latest available version, if any.
+Updates Nextstrain pathogens and runtimes to the latest available versions, if any.
 
-The default runtime (docker) is updated when this command is run
-without arguments.  Provide a runtime name as an argument to update a specific
-runtime instead.
+When this command is run without arguments, the default version for each set up
+pathogen (none) and the default runtime (docker)
+are updated.  Provide one or more pathogens and/or runtimes as arguments to
+update a select list instead.
 
 Three runtimes currently support updates: Docker, Conda, and Singularity.
 Updates may take several minutes as new software versions are downloaded.
@@ -33,9 +36,19 @@ positional arguments
 
 
 
-.. option:: <runtime>
+.. option:: <pathogen>|<runtime>
 
-    The Nextstrain runtime to check. One of {docker, conda, singularity, ambient, aws-batch}. (default: docker)
+    The Nextstrain pathogens and/or runtimes to update.
+
+    A pathogen is the name (and optionally, version) of a previously
+    set up pathogen.  See :command-reference:`nextstrain setup`.  If no
+    version is specified, then the default version will be updated to
+    the latest available version.
+
+    A runtime is one of {docker, conda, singularity, ambient, aws-batch}.
+
+
+
 
 options
 =======

--- a/doc/commands/version.rst
+++ b/doc/commands/version.rst
@@ -12,7 +12,7 @@ nextstrain version
 
 .. code-block:: none
 
-    usage: nextstrain version [-h] [--verbose]
+    usage: nextstrain version [-h] [--verbose] [--pathogens] [--runtimes]
 
 
 Prints the version of the Nextstrain CLI.
@@ -28,5 +28,13 @@ options
 
 .. option:: --verbose
 
-    Show versions of individual Nextstrain components in each runtime
+    Show versions of each runtime, plus select individual Nextstrain components within, and versions of each pathogen, including URLs
+
+.. option:: --pathogens
+
+    Show pathogen versions; implied by --verbose
+
+.. option:: --runtimes
+
+    Show runtime versions; implied by --verbose
 

--- a/doc/config/paths.rst
+++ b/doc/config/paths.rst
@@ -34,6 +34,14 @@ If necessary, the defaults can be overridden by environment variables.
 
     Default is :file:`{${NEXTSTRAIN_HOME}}/lock`.
 
+.. envvar:: NEXTSTRAIN_PATHOGENS
+
+    Directory for pathogen workflow data managed by :doc:`/commands/setup`,
+    e.g. local copies of pathogen repos like `nextstrain/measles
+    <https://github.com/nextstrain/measles>`__.
+
+    Default is :file:`{${NEXTSTRAIN_HOME}}/pathogens/`.
+
 .. envvar:: NEXTSTRAIN_RUNTIMES
 
     Directory for runtime-specific data, e.g. Singularity images or a Conda

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,6 +39,7 @@ Table of Contents
     :titlesonly:
     :maxdepth: 3
 
+    commands/run
     commands/build
     commands/view
     commands/deploy

--- a/nextstrain/cli/__init__.py
+++ b/nextstrain/cli/__init__.py
@@ -15,10 +15,9 @@ import sys
 import traceback
 from argparse import ArgumentParser, Action, SUPPRESS
 from textwrap import dedent
-from types    import SimpleNamespace
 
 from .argparse    import HelpFormatter, register_commands, register_default_command
-from .command     import all_commands, version
+from .command     import all_commands
 from .debug       import DEBUGGING
 from .errors      import NextstrainCliError, UsageError
 from .util        import warn
@@ -87,8 +86,11 @@ def register_version_alias(parser):
 
     class run_version_command(Action):
         def __call__(self, *args, **kwargs):
-            opts = SimpleNamespace(verbose = False)
-            sys.exit( version.run(opts) )
+            # Go thru parse_args() rather than creating an opts Namespace
+            # ourselves and passing it directly to version.run() so that the
+            # version command's options pick up their normal defaults.
+            opts = parser.parse_args(["version"])
+            sys.exit( opts.__command__.run(opts) )
 
     parser.add_argument(
         "--version",

--- a/nextstrain/cli/command/__init__.py
+++ b/nextstrain/cli/command/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    run,
     build,
     view,
     deploy,
@@ -25,6 +26,7 @@ from . import (
 # in various user interfaces, e.g. `nextstrain --help`.
 #
 all_commands = [
+    run,
     build,
     view,
     deploy,

--- a/nextstrain/cli/command/build.py
+++ b/nextstrain/cli/command/build.py
@@ -339,7 +339,7 @@ def assert_overlay_volumes_support(opts):
             """)
 
 
-def pathogen_volumes(directory: Path) -> Tuple[NamedVolume, NamedVolume]:
+def pathogen_volumes(directory: Path, *, name = "build") -> Tuple[NamedVolume, NamedVolume]:
     """
     Discern the pathogen **build volume** and **working volume** for a given
     *directory* path.
@@ -368,6 +368,15 @@ def pathogen_volumes(directory: Path) -> Tuple[NamedVolume, NamedVolume]:
     NamedVolume(name='build', src=...Path('.../tests/data'), dir=True, writable=True)
     >>> docker.mount_point(build_volume) <= docker.mount_point(working_volume)
     True
+
+    An alternative *name* for the **build volume** (and by extension the
+    initial part of the name of the **working volume**) may be passed.
+
+    >>> build_volume, working_volume = pathogen_volumes(Path("tests/data/pathogen-repo/ingest/"), name = "pathogen")
+    >>> build_volume # doctest: +ELLIPSIS
+    NamedVolume(name='pathogen', src=...Path('.../tests/data/pathogen-repo'), dir=True, writable=True)
+    >>> working_volume # doctest: +ELLIPSIS
+    NamedVolume(name='pathogen/ingest', src=...Path('.../tests/data/pathogen-repo/ingest'), dir=True, writable=True)
     """
     if not directory.is_dir():
         err = f"Build path {str(directory)!r} does not exist or is not a directory."
@@ -402,14 +411,14 @@ def pathogen_volumes(directory: Path) -> Tuple[NamedVolume, NamedVolume]:
     for marker in (d / marker_name for d in [working_dir, *working_dir.parents]):
         if marker.exists():
             debug(f"{marker}: exists")
-            build_volume = NamedVolume("build", marker.parent)
+            build_volume = NamedVolume(name, marker.parent)
             break
         else:
             debug(f"{marker}: does not exist")
     else:
-        build_volume = NamedVolume("build", working_dir)
+        build_volume = NamedVolume(name, working_dir)
 
-    debug(f"Using {build_volume.src} as build volume")
+    debug(f"Using {build_volume.src} as {name} volume")
 
     # Construct the working volume name based on its relative path within the
     # build volume we just determined.  The working volume should always be

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -35,7 +35,6 @@ checked runtimes are supported.
 """
 
 from functools import partial
-from .. import config
 from ..argparse import SKIP_AUTO_DEFAULT_IN_HELP, runner_module_argument
 from ..types import Options
 from ..util import colored, check_for_new_version, runner_name, print_and_check_setup_tests
@@ -117,7 +116,6 @@ def run(opts: Options) -> int:
             default_runner = supported_runners[0]
             print()
             print("Setting default runtime to %s." % runner_name(default_runner))
-            config.set("core", "runner", runner_name(default_runner))
             default_runner.set_default_config()
     else:
         if set(opts.runners) == set(all_runners):

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -44,6 +44,11 @@ from ..runner import all_runners, all_runners_by_name, default_runner # noqa: F4
 __doc__ = (__doc__ or "").format(default_runner_name = runner_name(default_runner))
 
 
+# XXX TODO: Add support for checking pathogen setups too?  Not sure this makes
+# much sense.
+#   -trs, 3 March 2025
+
+
 def register_parser(subparser):
     """
     %(prog)s [--set-default] [<runtime> [<runtime> ...]]

--- a/nextstrain/cli/command/check_setup.py
+++ b/nextstrain/cli/command/check_setup.py
@@ -38,7 +38,7 @@ from functools import partial
 from .. import config
 from ..argparse import SKIP_AUTO_DEFAULT_IN_HELP, runner_module_argument
 from ..types import Options
-from ..util import colored, check_for_new_version, runner_name, print_and_check_runner_tests
+from ..util import colored, check_for_new_version, runner_name, print_and_check_setup_tests
 from ..runner import all_runners, all_runners_by_name, default_runner # noqa: F401 (it's wrong; we use it in run())
 
 
@@ -98,7 +98,7 @@ def run(opts: Options) -> int:
     for runner, tests in runner_tests:
         print(colored("blue", "#"), "Checking %s…" % (runner_name(runner)))
 
-        ok = print_and_check_runner_tests(tests)
+        ok = print_and_check_setup_tests(tests)
 
         if ok:
             supported = success("supported")

--- a/nextstrain/cli/command/run.py
+++ b/nextstrain/cli/command/run.py
@@ -1,0 +1,306 @@
+"""
+Runs a pathogen workflow in a Nextstrain runtime with config and input from an
+analysis directory and outputs written to that same directory.
+
+This command focuses on the routine running of existing pathogen workflows
+(mainly provided by Nextstrain) using your own configuration, data, and other
+supported customizations.  Pathogens are initially set up using `nextstrain
+setup` and can be updated over time as desired using `nextstrain update`.
+Multiple versions of a pathogen may be set up and run independently without
+conflict, allowing for comparisons of output across versions.  The same
+pathogen workflow may also be concurrently run multiple times with separate
+analysis directories (i.e. different configs, input data, etc.) without
+conflict, allowing for independent outputs and analyses.
+
+Compared to `nextstrain build`, this command is a higher-level interface to
+running pathogen workflows that does not require knowledge of Git or management
+of pathogen repositories and source code.  For now, the `nextstrain build`
+command remains more suitable for active authorship and development of
+workflows.
+
+All Nextstrain runtimes are supported.  For AWS Batch, all runs will detach
+after submission and `nextstrain build` must be used to further monitor or
+manage the run and download results after completion.
+"""
+
+from inspect import cleandoc
+from shlex import quote as shquote
+from textwrap import dedent
+from .. import runner
+from ..argparse import add_extended_help_flags, MkDirectoryPath, SKIP_AUTO_DEFAULT_IN_HELP
+from ..debug import DEBUGGING
+from ..errors import UserError
+from ..pathogens import PathogenVersion
+from ..runner import aws_batch, docker, singularity
+from ..util import byte_quantity, split_image_name
+from ..volume import NamedVolume
+from . import build
+
+
+def register_parser(subparser):
+    """
+    %(prog)s [options] <pathogen-name>[@<version>] <workflow-name> <analysis-directory> [<target> [<target> [...]]]
+    %(prog)s --help
+    """
+
+    parser = subparser.add_parser("run", help = "Run pathogen workflow", add_help = False)
+
+    # Positional parameters
+    parser.add_argument(
+        "pathogen",
+        metavar = "<pathogen-name>[@<version>]",
+        help    = cleandoc(f"""
+            The name (and optionally, version) of a previously set up pathogen.
+            See :command-reference:`nextstrain setup`.  If no version is
+            specified, then the default version (if any) will be used.
+
+            Required.
+            """))
+
+    parser.add_argument(
+        "workflow",
+        metavar = "<workflow-name>",
+        help    = cleandoc(f"""
+            The name of a workflow for the given pathogen, e.g. typically
+            ``ingest``, ``phylogenetic``, or ``nextclade``.
+
+            Available workflows may vary per pathogen (and possibly between
+            pathogen version).  Some pathogens may provide multiple variants or
+            base configurations of a top-level workflow, e.g. as in
+            ``phylogenetic/mpxv`` and ``phylogenetic/hmpxv1``.  Refer to the
+            pathogen's own documentation for valid workflow names.
+
+            Workflow names conventionally correspond directly to directory
+            paths in the pathogen source, but this may not always be the case.
+
+            Required.
+            """))
+
+    parser.add_argument(
+        "analysis_directory",
+        metavar = "<analysis-directory>",
+        type    = MkDirectoryPath(),
+        help    = cleandoc("""
+            The path to your analysis directory.  The workflow uses this as its
+            working directory for all local inputs and outputs, including
+            config files, input data files, resulting output data files, log
+            files, etc.
+
+            We recommend keeping your config files and static input files (e.g.
+            reference sequences, inclusion/exclusion lists, annotations, etc.)
+            in a version control system, such as Git, so you can keep track of
+            changes over time and recover previous versions.  When using
+            version control, dynamic inputs (e.g. downloaded input filefs) and
+            outputs (e.g. resulting data files, log files, etc.) should
+            generally be marked as ignored/excluded from tracking, such as via
+            :file:`.gitignore` for Git.
+
+            An empty directory will be automatically created if the given path
+            does not exist but its parent directory does.
+
+            Required.
+            """))
+
+    parser.add_argument(
+        "targets",
+        metavar = "<target>",
+        nargs   = "*",
+        help    = cleandoc("""
+            One or more workflow targets.  A target is either a file path
+            (relative to :option:`<analysis-directory>`) produced by the
+            workflow or the name of a workflow rule or step.
+
+            Available targets will vary per pathogen (and between versions of
+            pathogens).  Refer to the pathogen's own documentation for valid
+            targets.
+
+            Optional.
+            """))
+
+    parser.add_argument(
+        "--force",
+        help    = "Force a rerun of the whole workflow even if everything seems up-to-date.",
+        action  = "store_true")
+
+    # XXX TODO: Consider if and how to share argument definitions with `build`?
+    # Starting with copying for now, but the expectation is they should be
+    # aligned as much as possible (at least where they overlap).
+    #  -trs, 1 Nov 2024
+
+    parser.add_argument(
+        "--cpus",
+        help    = "Number of CPUs/cores/threads/jobs to utilize at once.  "
+                  "Limits containerized (Docker, AWS Batch) workflow runs to this amount.  "
+                  "Informs Snakemake's resource scheduler when applicable.  "
+                  "Informs the AWS Batch instance size selection.  "
+                  "By default, no constraints are placed on how many CPUs are used by a workflow run; "
+                  "workflow runs may use all that are available if they're able to.",
+        metavar = "<count>",
+        type    = int)
+
+    parser.add_argument(
+        "--memory",
+        help    = "Amount of memory to make available to the workflow run.  "
+                  "Units of b, kb, mb, gb, kib, mib, gib are supported.  "
+                  "Limits containerized (Docker, AWS Batch) workflow runs to this amount.  "
+                  "Informs Snakemake's resource scheduler when applicable.  "
+                  "Informs the AWS Batch instance size selection.  ",
+        metavar = "<quantity>",
+        type    = byte_quantity)
+
+    # XXX TODO: AWS Batch support for `nextstrain run`.  Include options like
+    # --detach, --detach-on-interrupt, --attach, --cancel, etc?  For now, only
+    # support detached Batch builds and kick the can to `build` for further
+    # monitoring/management.  Maybe we leave it that way?
+    #   -trs, 1 Nov 2024 & 28 Feb 2025
+
+    parser.add_argument(
+        "--exclude-from-upload",
+        metavar = "<pattern>",
+        help    = dedent(f"""\
+            Exclude files matching ``<pattern>`` from being uploaded as part of
+            the remote build.  Shell-style advanced globbing is supported, but
+            be sure to escape wildcards or quote the whole pattern so your
+            shell doesn't expand them.  May be passed more than once.
+            Currently only supported when also using :option:`--aws-batch`.
+            Default is to upload the entire pathogen build directory (except
+            for some ancillary files which are always excluded).
+
+            Note that files excluded from upload may still be downloaded from
+            the remote build, e.g. if they're created by it, and if downloaded
+            will overwrite the local files.  When attaching to the build, use
+            :option:`nextstrain build --no-download` to avoid downloading any
+            files or :option:`nextstrain build --exclude-from-download` to
+            avoid downloading specific files.
+
+            Besides basic glob features like single-part wildcards (``*``),
+            character classes (``[…]``), and brace expansion (``{{…, …}}``),
+            several advanced globbing features are also supported: multi-part
+            wildcards (``**``), extended globbing (``@(…)``, ``+(…)``, etc.),
+            and negation (``!…``).
+
+            Patterns should be relative to the build directory.
+
+            {SKIP_AUTO_DEFAULT_IN_HELP}
+            """),
+        action  = "append")
+
+    # Support --help and --help-all
+    add_extended_help_flags(parser)
+
+    # Register runner flags and arguments
+    #
+    # Note that we intentionally do not pass "..." (Ellipsis) as an element in
+    # "exec" because this `nextstrain run` command, unlike `nextstrain build`,
+    # is intended to fully encapsulate the details of Snakemake's invocation in
+    # order to present a simplified, stable interface.
+    #   -trs, 6 Feb 2025
+    runner.register_runners(
+        parser,
+        exec = ["snakemake"]) # Other default exec args defined below
+
+    return parser
+
+
+def run(opts):
+    build.assert_overlay_volumes_support(opts)
+
+    # Assert AWS Batch support; this command requires overlays.
+    if opts.__runner__ is aws_batch and not docker.image_supports(docker.IMAGE_FEATURE.aws_batch_overlays, opts.image):
+        raise UserError(f"""
+            The Nextstrain runtime image version in use
+
+                {opts.image}
+
+            is too old to support `nextstrain run` with AWS Batch.
+
+            Please update the runtime image to at least version
+
+                {split_image_name(opts.image)[0]}:{docker.IMAGE_FEATURE.aws_batch_overlays.value}
+
+            using `nextstrain update docker`.  Alternatively, use a runtime
+            other than AWS Batch.
+            """)
+
+    # Resolve pathogen and workflow names to a local workflow directory.
+    pathogen = PathogenVersion(opts.pathogen)
+
+    workflow_directory = pathogen.workflow_path(opts.workflow)
+
+    if not workflow_directory.is_dir() or not (workflow_directory / "Snakefile").is_file():
+        raise UserError(f"""
+            No {opts.workflow!r} workflow for pathogen {opts.pathogen!r} found {f"in {str(workflow_directory)!r}" if DEBUGGING else "locally"}.
+
+            Maybe you need to update to a newer version of the pathogen?
+
+            Hint: to update the pathogen, run `nextstrain update {shquote(pathogen.name)}`.
+            """)
+
+    # The pathogen volume is the pathogen directory (i.e. repo).
+    # The workflow volume is the workflow directory within the pathogen directory.
+    # The build volume is the user's analysis directory and will be the working directory.
+    pathogen_volume, workflow_volume = build.pathogen_volumes(workflow_directory, name = "pathogen")
+    build_volume = NamedVolume("build", opts.analysis_directory)
+
+    # for containerized runtimes (e.g. Docker, Singularity, and AWS Batch)
+    opts.volumes.append(pathogen_volume)
+    opts.volumes.append(build_volume)
+
+    print(f"Running the {opts.workflow!r} workflow for pathogen {pathogen}")
+
+    # Set up Snakemake invocation.
+    opts.default_exec_args += [
+        # Useful to see what's going on; see also 08ffc925.
+        "--printshellcmds",
+
+        # In our experience,¹ it's rarely useful to fail on incomplete outputs
+        # (Snakemake's default behaviour) instead of automatically regenerating
+        # them.
+        #
+        # ¹ <https://discussion.nextstrain.org/t/snakemake-throwing-incompletefilesexception-when-using-forceall/1397/4>
+        "--rerun-incomplete",
+
+        # Pin down rerun triggers so they don't drift over time as Snakemake
+        # changes the defaults.  In the past, changes to this have been
+        # confusing/caused errors.
+        "--rerun-triggers", "code", "input", "mtime", "params", "software-env",
+
+        *(["--forceall"]
+            if opts.force else []),
+
+        # Workdir will be the analysis volume (/nextstrain/build in a
+        # containerized runtime), so explicitly point to the Snakefile.
+        "--snakefile=%s/Snakefile" % (
+            docker.mount_point(workflow_volume)
+                if opts.__runner__ in {docker, singularity, aws_batch} else
+            workflow_volume.src.resolve(strict = True)),
+
+        # Pass thru appropriate resource options.
+        #
+        # Snakemake requires the --cores option as of 5.11, so provide a
+        # default to insulate our users from this and make Nextstrain builds
+        # fast-by-default.  For more rationale/details, see a similar comment
+        # in nextstrain/cli/command/build.py.
+        #   -trs, 1 Nov 2024
+        "--cores=%s" % (opts.cpus or "all"),
+
+        # Named MB but is really MiB, so convert our count of bytes to MiB
+        *(["--resources=mem_mb=%d" % (opts.memory // 1024**2)]
+            if opts.memory else []),
+
+        "--",
+
+        *opts.targets,
+    ]
+
+    # XXX TODO: AWS Batch support for `nextstrain run`.  For now, only support
+    # detached Batch builds and kick the can to `build` for further
+    # monitoring/management.  In the future, maybe we'll support the full set
+    # of AWS Batch options (see related comment in register_parser() above).
+    #   -trs, 28 Feb 2025
+    if opts.__runner__ is aws_batch:
+        opts.detach = True
+        opts.attach = None
+        opts.cancel = None
+
+    return runner.run(opts, working_volume = build_volume, cpus = opts.cpus, memory = opts.memory)

--- a/nextstrain/cli/command/setup.py
+++ b/nextstrain/cli/command/setup.py
@@ -13,8 +13,8 @@ from textwrap import dedent
 
 from .. import config, console
 from ..argparse import runner_module_argument
-from ..util import colored, runner_name, print_and_check_runner_tests
-from ..types import Options, RunnerTestResults
+from ..util import colored, runner_name, print_and_check_setup_tests
+from ..types import Options, SetupTestResults
 from ..runner import all_runners_by_name, configured_runner, default_runner # noqa: F401 (it's wrong; we use it in run())
 
 
@@ -70,9 +70,9 @@ def run(opts: Options) -> int:
     print(heading(f"Checking setup…"))
 
     if not opts.dry_run:
-        tests: RunnerTestResults = opts.runner.test_setup()
+        tests: SetupTestResults = opts.runner.test_setup()
 
-        ok = print_and_check_runner_tests(tests)
+        ok = print_and_check_setup_tests(tests)
 
         if not ok:
             print()

--- a/nextstrain/cli/command/setup.py
+++ b/nextstrain/cli/command/setup.py
@@ -11,7 +11,7 @@ Exits with an error code if automated set up fails or if setup checks fail.
 from functools import partial
 from textwrap import dedent
 
-from .. import config, console
+from .. import console
 from ..argparse import runner_module_argument
 from ..util import colored, runner_name, print_and_check_setup_tests
 from ..types import Options, SetupTestResults
@@ -88,7 +88,6 @@ def run(opts: Options) -> int:
         print("Setting default runtime to %s." % runner_name(default_runner))
 
         if not opts.dry_run:
-            config.set("core", "runner", runner_name(default_runner))
             default_runner.set_default_config()
 
     # Warn if this isn't the default runner.

--- a/nextstrain/cli/command/setup.py
+++ b/nextstrain/cli/command/setup.py
@@ -1,32 +1,66 @@
 """
-Sets up a Nextstrain runtime for use with `nextstrain build`, `nextstrain
-view`, etc.
+Sets up a Nextstrain pathogen for use with `nextstrain run` or a Nextstrain
+runtime for use with `nextstrain run`, `nextstrain build`, `nextstrain view`,
+etc.
 
-Only the Conda runtime currently supports automated set up, but this command
-may still be used with other runtimes to check an existing (manual) setup and
-set the runtime as the default on success.
+For pathogens, set up involves downloading a specific version of the pathogen's
+Nextstrain workflows.  By convention, this download is from Nextstrain's
+repositories.  More than one version of the same pathogen may be set up and
+used independently.  This can be useful for comparing analyses across workflow
+versions.  A default version can be set.
+
+For runtimes, only the Conda runtime currently supports fully-automated set up,
+but this command may still be used with other runtimes to check an existing
+(manual) setup and set the runtime as the default on success.
 
 Exits with an error code if automated set up fails or if setup checks fail.
 """
 from functools import partial
-from textwrap import dedent
+from inspect import cleandoc
+from textwrap import dedent, indent
+from typing import Union
 
 from .. import console
-from ..argparse import runner_module_argument
-from ..util import colored, runner_name, print_and_check_setup_tests
-from ..types import Options, SetupTestResults
-from ..runner import all_runners_by_name, configured_runner, default_runner # noqa: F401 (it's wrong; we use it in run())
+from ..errors import UserError
+from ..util import colored, runner_module, runner_name, print_and_check_setup_tests
+from ..types import Options, RunnerModule, SetupTestResults
+from ..pathogens import PathogenVersion, pathogen_defaults
+from ..runner import all_runners_by_name, runner_defaults
+
+
+
+heading = partial(colored, "bold")
+failure = partial(colored, "red")
 
 
 def register_parser(subparser):
-    parser = subparser.add_parser("setup", help = "Set up a runtime")
+    """
+    %(prog)s [--dry-run] [--force] [--set-default] <pathogen-name>[@<version>[=<url>]]
+    %(prog)s [--dry-run] [--force] [--set-default] <runtime-name>
+    %(prog)s --help
+    """
+    parser = subparser.add_parser("setup", help = "Set up a pathogen or runtime")
 
     parser.add_argument(
-        "runner",
-        help     = "The Nextstrain runtime to set up. "
-                   f"One of {{{', '.join(all_runners_by_name)}}}.",
-        metavar  = "<runtime>",
-        type     = runner_module_argument)
+        "arg",
+        help = dedent(f"""\
+            The Nextstrain pathogen or runtime to set up.
+
+            A pathogen is usually the plain name of a Nextstrain-maintained
+            pathogen (e.g. ``measles``), optionally with an ``@<version>``
+            specifier (e.g. ``measles@v42``).  If ``<version>`` is specified in
+            this case, it must be a tag name (i.e. a release name), development
+            branch name, or a development commit id.
+
+            A pathogen may also be fully-specified as ``<name>@<version>=<url>``
+            where ``<name>`` and ``<version>`` in this case are (mostly)
+            arbitrary and ``<url>`` points to a ZIP file containing the
+            pathogen repository contents (e.g.
+            ``https://github.com/nextstrain/measles/zipball/83b446d67fc03de2ce1c72bb1345b4c4eace7231``).
+
+            A runtime is one of {{{', '.join(all_runners_by_name)}}}.
+            """),
+        metavar = "<pathogen>|<runtime>")
 
     parser.add_argument(
         "--dry-run",
@@ -41,7 +75,7 @@ def register_parser(subparser):
 
     parser.add_argument(
         "--set-default",
-        help   = "Use the runtime as the default if set up is successful.",
+        help   = "Use this pathogen version or runtime as the default if set up is successful.",
         action = "store_true")
 
     return parser
@@ -49,14 +83,37 @@ def register_parser(subparser):
 
 @console.auto_dry_run_indicator()
 def run(opts: Options) -> int:
-    global default_runner
+    try:
+        runner = runner_module(opts.arg)
+    except ValueError as e1:
+        try:
+            pathogen = PathogenVersion(opts.arg, new_setup = True)
+        except Exception as e2:
+            raise UserError(f"""
+                Unable to set up {opts.arg!r}.
 
-    heading = partial(colored, "bold")
-    failure = partial(colored, "red")
+                It's not a valid runtime:
+
+                {{e1}}
+
+                nor pathogen:
+
+                {{e2}}
+
+                as specified.  Double check your spelling and syntax?
+                """, e1 = indent(str(e1), "    "), e2 = indent(str(e2), "    "))
+        else:
+            arg             = pathogen
+            defaults        = partial(pathogen_defaults, pathogen.name)
+            kind_of_default = "pathogen default version"
+    else:
+        arg             = runner
+        defaults        = runner_defaults
+        kind_of_default = "default runtime"
 
     # Setup
-    print(heading(f"Setting up {runner_name(opts.runner)}…"))
-    setup_ok = opts.runner.setup(dry_run = opts.dry_run, force = opts.force)
+    print(heading(f"Setting up {nameof(arg)}…"))
+    setup_ok = arg.setup(dry_run = opts.dry_run, force = opts.force)
 
     if setup_ok is None:
         print("Automated set up is not supported, but we'll check for a manual setup.")
@@ -70,7 +127,7 @@ def run(opts: Options) -> int:
     print(heading(f"Checking setup…"))
 
     if not opts.dry_run:
-        tests: SetupTestResults = opts.runner.test_setup()
+        tests: SetupTestResults = arg.test_setup()
 
         ok = print_and_check_setup_tests(tests)
 
@@ -83,33 +140,95 @@ def run(opts: Options) -> int:
 
     # Optionally set as default
     if opts.set_default:
-        default_runner = opts.runner
         print()
-        print("Setting default runtime to %s." % runner_name(default_runner))
+        print(f"Setting {kind_of_default} to {nameof(arg)}.")
 
         if not opts.dry_run:
-            default_runner.set_default_config()
+            arg.set_default_config()
 
-    # Warn if this isn't the default runner.
-    if default_runner is not opts.runner:
+    # Evaluate defaults now, as the new setup may have configured a new default
+    # (above) or changed the intuited implicit default.
+    if opts.set_default and opts.dry_run:
+        # Assume setting default works for sake of dry run.
+        default = configured_default = arg
+    else:
+        # Otherwise, get real defaults.  But note that under a dry run that's
+        # not setting the default too, this is likely to be incorrect when the
+        # new setup we only pretended to do will in reality perturb the
+        # implicit default.
+        #
+        # XXX TODO: Maybe fix the above with a state context object we can
+        # update for dry run or mocks or something similar.  Not now, though.
+        # This is a pervasive problem.
+        #   -trs, 10 Jan 2025
+        default, configured_default = defaults()
+
+    assert not configured_default or default == configured_default, \
+        f"{configured_default=} {default=}"
+
+    # Warn if this isn't the default
+    if default != arg:
         print()
-        if not configured_runner:
-            print(f"Warning: No default runtime is configured so {runner_name(default_runner)} will be used.")
+        if not configured_default:
+            if default:
+                print(f"Warning: No {kind_of_default} is configured so {nameof(default)} (not {nameof(arg)}) will be used implicitly.")
+            else:
+                print(f"Warning: No {kind_of_default} is configured and no implicit default is intuitable.")
         else:
-            print(f"Note that your default runtime is still {runner_name(default_runner)}.")
+            assert default
+            print(f"Note that your {kind_of_default} is still {nameof(default)}.")
+
+        if kind_of_default == "default runtime":
+            examples = cleandoc(f"""
+                nextstrain run --{nameof(arg)} …
+                nextstrain build --{nameof(arg)} …
+                nextstrain view --{nameof(arg)} …
+                """)
+        elif kind_of_default == "pathogen default version":
+            examples = cleandoc(f"""
+                nextstrain run {nameof(arg)} …
+                """)
+        else:
+            examples = None
+
+        assert examples
+
         print()
         print(dedent(f"""\
-            You can use {runner_name(opts.runner)} on an ad-hoc basis with commands like `nextstrain build`,
-            `nextstrain view`, etc. by passing them the --{runner_name(opts.runner)} option, e.g.:
+            You can use {nameof(arg)} on an ad-hoc basis by specifying it
+            explicitly, e.g.:
 
-                nextstrain build --{runner_name(opts.runner)} …
+            {{examples}}
 
-            If you want to use {runner_name(opts.runner)} by default instead, re-run this
-            command with the --set-default option, e.g.:
+            If you want to use {nameof(arg)} by default instead, re-run
+            this command with the --set-default option, e.g.:
 
-                nextstrain setup --set-default {runner_name(opts.runner)}\
+                nextstrain setup --set-default {nameof(arg)}\
+            """).format(examples = indent(examples, "    ")))
+
+    # Warn about relying on implicit defaults
+    if default and default == arg and not configured_default:
+        print()
+        print(f"Warning: No {kind_of_default} is configured but {nameof(default)} will be used implicitly.")
+        print(f"Future changes (e.g. additional `nextstrain setup`s) may affect this implicit default.")
+        print()
+        print(dedent(f"""\
+            If you want to use {nameof(arg)} by default regardless of future
+            changes, re-run this command with the --set-default option, e.g.:
+
+                nextstrain setup --set-default {nameof(arg)}\
             """))
 
     print()
-    print("All good!  Set up of", runner_name(opts.runner), "complete.")
+    print("All good!  Set up of", nameof(arg), "complete.")
     return 0
+
+
+# str(x) doesn't look for x.__str__ but type(x).__str__, which means we can't
+# just define __str__ in a module have it be called by str(module).  We can't
+# modify the module type either, so this function is necessary.
+#   -trs, 25 Feb 2025
+def nameof(arg: Union[RunnerModule, PathogenVersion]) -> str:
+    if isinstance(arg, RunnerModule):
+        return runner_name(arg)
+    return str(arg)

--- a/nextstrain/cli/command/version.py
+++ b/nextstrain/cli/command/version.py
@@ -5,6 +5,7 @@ Prints the version of the Nextstrain CLI.
 import sys
 from textwrap import indent
 from ..__version__ import __version__
+from ..pathogens import all_pathogen_versions_by_name, every_pathogen_default_by_name
 from ..runner import all_runners, default_runner
 from ..util import runner_name, standalone_installation
 
@@ -13,7 +14,17 @@ def register_parser(subparser):
 
     parser.add_argument(
         "--verbose",
-        help   = "Show versions of individual Nextstrain components in each runtime",
+        help   = "Show versions of each runtime, plus select individual Nextstrain components within, and versions of each pathogen, including URLs",
+        action = "store_true")
+
+    parser.add_argument(
+        "--pathogens",
+        help   = "Show pathogen versions; implied by --verbose",
+        action = "store_true")
+
+    parser.add_argument(
+        "--runtimes",
+        help   = "Show runtime versions; implied by --verbose",
         action = "store_true")
 
     return parser
@@ -27,15 +38,38 @@ def run(opts):
         print("Python")
         print("  " + sys.executable)
         print(indent(sys.version, "  "))
-        print()
 
-        print("Runners")
-        for runner in all_runners:
+    if opts.runtimes or (opts.verbose and not opts.pathogens):
+        print()
+        print("Runtimes")
+        for i, runner in enumerate(all_runners):
+            if i != 0:
+                print()
             print("  " + runner_name(runner), "(default)" if runner is default_runner else "")
-            versions = list(runner.versions())
-            if versions:
-                for version in versions:
-                    print("    " + version)
+            versions = iter(runner.versions())
+            version = next(versions, None)
+            if version:
+                print("    " + version)
             else:
                 print("    unknown")
-            print()
+            if opts.verbose:
+                for version in versions:
+                    print("    " + version)
+
+    if opts.pathogens or (opts.verbose and not opts.runtimes):
+        print()
+        print("Pathogens")
+        if pathogens := all_pathogen_versions_by_name():
+            defaults = every_pathogen_default_by_name(pathogens)
+
+            for i, (name, versions) in enumerate(pathogens.items()):
+                if i != 0:
+                    print()
+                print("  " + name)
+                for version in versions.values():
+                    is_default = version == defaults.get(name)
+                    print("    " + str(version) + (f"={version.url or ''}" if opts.verbose else ""), "(default)" if is_default else "")
+                    if opts.verbose:
+                        print("      " + str(version.path))
+        else:
+            print("  (none)")

--- a/nextstrain/cli/pathogens.py
+++ b/nextstrain/cli/pathogens.py
@@ -1,0 +1,906 @@
+"""
+Pathogen workflows.
+"""
+import json
+import os.path
+import re
+import requests
+import traceback
+import yaml
+from base64 import b32encode, b32decode
+from itertools import groupby
+from tempfile import TemporaryFile
+from textwrap import indent
+from os import chmod, stat
+from pathlib import Path, PurePath
+from shlex import quote as shquote
+from shutil import copyfileobj, rmtree
+from stat import S_IXUSR, S_IXGRP, S_IXOTH, S_IRGRP, S_IROTH
+from typing import Dict, List, NamedTuple, Optional, Tuple
+from urllib.parse import quote as urlquote
+from zipfile import ZipFile
+
+from . import config
+from .debug import DEBUGGING, debug
+from .errors import UserError
+from .paths import PATHOGENS
+from .types import SetupStatus, SetupTestResults, SetupTestResult, UpdateStatus
+from .url import URL
+from .util import parse_version_lax, print_and_check_setup_tests, request_list
+
+
+# XXX TODO: I'm not very happy with the entirety of the conceptual organization
+# and physical code organization in this file—in particular 1) the new_setup
+# flag for handling of new vs. existing setups, 2) the tension between the main
+# PathogenVersion class and the surrounding functions, and 3) the way the
+# PathogenVersion constructor inconsistently cares about what's on the
+# filesystem or not (e.g. for defaults)—but it does the job for now.  If it
+# continues to feel ill-fitting for the various uses, I suspect I'll end up
+# reorganizing it after a while.  This is also to say, if you're working in
+# this code and have ideas for improving its organization, please do
+# suggest/discuss them!
+#   -trs, 15 Jan 2025
+
+
+class PathogenSpec(NamedTuple):
+    """
+    A parsed pathogen spec of the form ``[<name>][@<version>][=<url>]``,
+    represented as a named tuple.
+
+    No validation takes place and all fields are optional.  This data structure
+    represents the very first step of handling a user-provided pathogen spec.
+    As such it focuses only on accurately representing what the user provided.
+    Validation is left for subsequent steps, where requirements can
+    appropriately vary depending on context (e.g. program entry point).
+    """
+    name: Optional[str]
+    version: Optional[str]
+    url: Optional[URL]
+
+    def __str__(self) -> str:
+        return (self.name or "") + "@" + (self.version or "") + "=" + (str(self.url) or "")
+
+    @staticmethod
+    def parse(name_version_url: str) -> 'PathogenSpec':
+        """
+        >>> PathogenSpec.parse("measles")
+        PathogenSpec(name='measles', version=None, url=None)
+
+        >>> PathogenSpec.parse("measles@v2")
+        PathogenSpec(name='measles', version='v2', url=None)
+
+        >>> PathogenSpec.parse("measles@v2 = https://example.com/a.zip")
+        PathogenSpec(name='measles', version='v2', url=URL(scheme='https', netloc='example.com', path='/a.zip', query='', fragment=''))
+
+        >>> PathogenSpec.parse("measles = https://example.com/x.zip")
+        PathogenSpec(name='measles', version=None, url=URL(scheme='https', netloc='example.com', path='/x.zip', query='', fragment=''))
+
+        >>> PathogenSpec.parse("measles@123@abc")
+        PathogenSpec(name='measles', version='123@abc', url=None)
+
+        >>> PathogenSpec.parse("@xyz")
+        PathogenSpec(name=None, version='xyz', url=None)
+
+        >>> PathogenSpec.parse("=https://example.com")
+        PathogenSpec(name=None, version=None, url=URL(scheme='https', netloc='example.com', path='', query='', fragment=''))
+
+        >>> PathogenSpec.parse("")
+        PathogenSpec(name=None, version=None, url=None)
+        """
+        if "=" in name_version_url:
+            name_version, url = name_version_url.split("=", 1)
+        else:
+            name_version, url = name_version_url, ""
+
+        if "@" in name_version:
+            name, version = name_version.split("@", 1)
+        else:
+            name, version = name_version, ""
+
+        name    = name.strip()    or None
+        version = version.strip() or None
+        url     = url.strip()     or None
+
+        # The parsing above is wrong if these assertions don't hold
+        assert name is None    or not set("@=") & set(name)
+        assert version is None or not set("=")  & set(version)
+
+        if url is not None:
+            url = URL(url)
+
+        return PathogenSpec(name, version, url)
+
+
+class PathogenVersion:
+    """
+    A pathogen setup with a specific *name* and *version*.
+
+    The entity used by ``nextstrain setup``, ``nextstrain update``, and
+    ``nextstrain run``.
+    """
+    spec: PathogenSpec
+
+    name: str
+    version: str
+
+    path: Path
+    registration_path: Path
+    setup_receipt_path: Path
+
+    setup_receipt: Optional[dict] = None
+    url: Optional[URL] = None
+
+
+    def __init__(self, name_version_url: str, new_setup: bool = False):
+        """
+        *name_version_url* is a pathogen spec string suitable for
+        :meth:`PathogenSpec.parse`.
+
+        If *new_setup* is ``False`` (the default), then the given pathogen spec
+        is required to refer to an existing pathogen setup, e.g. used by
+        ``nextstrain run``.
+
+        If *new_setup* is ``True``, then the given pathogen spec is expected to
+        have :meth:`.setup` called on it, e.g. used by ``nextstrain setup``.
+        """
+
+        name, version, url = self.spec = PathogenSpec.parse(name_version_url)
+
+        if not name:
+            if new_setup:
+                raise UserError(f"""
+                    No name specified in {name_version_url!r}.
+
+                    All pathogen setups must be given a name, e.g. as in NAME[@VERSION[=URL]].
+                    """)
+            else:
+                raise UserError(f"""
+                    No pathogen name specified in {name_version_url!r}.
+                    """)
+
+        if disallowed := set([os.path.sep, os.path.altsep or os.path.sep]) & set(name):
+            raise UserError(f"""
+                Disallowed character(s) {"".join(disallowed)!r} in name {name!r}.
+                """)
+
+        if url and not new_setup:
+            raise UserError(f"""
+                URL specified in {name_version_url!r}.
+
+                Pathogen setup URLs may only be specified for `nextstrain setup`.
+                """)
+
+        if url and not version:
+            raise UserError(f"""
+                URL specified without version in {name_version_url!r}.
+
+                A version must be specified when a setup URL is specified,
+                e.g. as in NAME@VERSION=URL.
+                """)
+
+        # Valid forms:
+        #   <name>
+        #   <name>@<version>
+        #   <name>@<version>=<url>
+        assert (name and not version and not url) \
+            or (name and     version and not url) \
+            or (name and     version and     url)
+
+        if not version:
+            if new_setup:
+                version = github_repo_latest_ref(f"nextstrain/{name}")
+            else:
+                version = default_version_of(name, implicit = True)
+
+        if not version:
+            if new_setup:
+                raise UserError(f"""
+                    No version specified in {name_version_url!r}.
+
+                    There's no default version intuitable, so a version must be
+                    specified, e.g. as in NAME@VERSION.
+                    """)
+            else:
+                # XXX TODO: This error case should maybe be handled outside of
+                # the constructor, with the constructor modified to raise a
+                # more generic FileNotFoundError instead.
+                #   -trs, 3 Feb 2025
+                if versions := versions_of(name):
+                    raise UserError(f"""
+                        No version specified in {name_version_url!r}.
+
+                        There's no default version set (or intuitable), so a version
+                        must be specified, e.g. as in NAME@VERSION.
+
+                        Existing versions of {name!r} you have set up are:
+
+                        {{versions}}
+
+                        Hint: You can set a default version for {name!r} by running:
+
+                            nextstrain setup --set-default {shquote(name)}@VERSION
+
+                        if you don't want to specify an explicit version every time.
+                        """, versions = indent("\n".join(f"{name}@{v}" for v in versions), "    "))
+                else:
+                    raise UserError(f"""
+                        No pathogen setup exists for {name_version_url!r}.
+
+                        Did you set it up yet?
+
+                        Hint: to set it up, run `nextstrain setup {shquote(name_version_url)}`.
+                        """)
+
+        self.name    = name
+        self.version = version
+
+        assert self.name
+        assert self.version
+
+        self.path = PATHOGENS / self.name / PathogenVersion.encode_version_dir(self.version)
+
+        self.registration_path  = self.path / "nextstrain-pathogen.yaml"
+        self.setup_receipt_path = self.path.with_suffix(self.path.suffix + ".json")
+
+        if not new_setup:
+            if not self.path.is_dir():
+                # XXX TODO: This error case should maybe be handled outside of
+                # the constructor, with the constructor modified to raise a
+                # more generic FileNotFoundError instead.
+                #   -trs, 3 Feb 2025
+                if versions := versions_of(name):
+                    raise UserError(f"""
+                        No pathogen setup exists for {name_version_url!r}{f" in {str(self.path)!r}" if DEBUGGING else ""}.
+
+                        Existing versions of {name!r} you have set up are:
+
+                        {{versions}}
+
+                        Did you mean one of those?
+                        """, versions = indent("\n".join(f"{name}@{v}" for v in versions), "    "))
+                else:
+                    raise UserError(f"""
+                        No pathogen setup exists for {name_version_url!r}{f" in {str(self.path)!r}" if DEBUGGING else ""}.
+
+                        Did you set it up yet?
+
+                        Hint: to set it up, run `nextstrain setup {shquote(name_version_url)}`.
+                        """)
+
+            try:
+                with self.setup_receipt_path.open(encoding = "utf-8") as f:
+                    self.setup_receipt = json.load(f)
+                    assert isinstance(self.setup_receipt, dict)
+            except FileNotFoundError:
+                pass
+
+            if not url and self.setup_receipt:
+                if url := self.setup_receipt.get("url"):
+                    url = URL(url)
+
+        if new_setup:
+            if not url:
+                url = github_repo_ref_zipball_url(f"nextstrain/{name}", version)
+
+            if not url:
+                raise UserError(f"""
+                    No setup URL specified in {name_version_url!r}.
+
+                    A default URL can not be determined, so a setup URL must be
+                    specified explicitly, e.g. as in NAME@VERSION=URL.
+                    """)
+
+            if url.scheme != "https":
+                raise UserError(f"""
+                    URL scheme is {url.scheme!r}, not {"https"!r}.
+
+                    Pathogen setup URLs must be https://.
+                    """)
+
+        self.url = url
+
+
+    def workflow_path(self, workflow: str) -> Path:
+        return self.path / workflow
+
+
+    def setup(self, dry_run: bool = False, force: bool = False) -> SetupStatus:
+        """
+        Downloads and installs this pathogen version from :attr:`.url`.
+        """
+        assert self.url
+
+        if not force and self.path.exists():
+            print(f"Using existing setup in {str(self.path)!r}.")
+            print(f"  Hint: if you want to ignore this existing setup, re-run `nextstrain setup` with --force.")
+            return True
+
+        if self.path.exists():
+            assert force
+            print(f"Removing existing setup {str(self.path)!r} to start fresh…")
+            if not dry_run:
+                rmtree(str(self.path))
+                self.setup_receipt_path.unlink(missing_ok = True)
+
+        try:
+            response = requests.get(str(self.url), stream = True)
+            response.raise_for_status()
+
+        except requests.exceptions.ConnectionError as err:
+            raise UserError(f"""
+                Could not connect to {self.url.netloc!r} to download
+                pathogen for setup:
+
+                    {type(err).__name__}: {err}
+
+                The URL may be invalid or you may be experiencing network
+                connectivity issues.
+                """) from err
+
+        except requests.exceptions.HTTPError as err:
+            if 400 <= err.response.status_code <= 499:
+                raise UserError(f"""
+                    Failed to download pathogen setup URL:
+
+                    {{urls}}
+
+                    The server responded with an error:
+
+                        {type(err).__name__}: {err}
+
+                    The URL may be incorrect (e.g. misspelled) or no longer
+                    accessible.
+                    """, urls = request_list(err.response)) from err
+
+            elif 500 <= err.response.status_code <= 599:
+                raise UserError(f"""
+                    Failed to download pathogen setup URL:
+
+                    {{urls}}
+
+                    The server responded with an error:
+
+                        {type(err).__name__}: {err}
+
+                    This may be a permanent error or a temporary failure, so it
+                    may be worth waiting a little bit and trying again a few
+                    more times.
+                    """, urls = request_list(err.response)) from err
+
+            else:
+                raise err
+
+
+        content_type = response.headers["Content-Type"]
+
+        if content_type != "application/zip":
+            raise UserError(f"""
+                Unexpected Content-Type {content_type!r} when downloading
+                pathogen setup URL:
+
+                {{urls}}
+
+                Expected 'application/zip', i.e. a ZIP file (.zip).
+                """, urls = request_list(response))
+
+        # Write remote ZIP file to a temporary local file so its seekable…
+        with TemporaryFile("w+b") as zipfh:
+            copyfileobj(response.raw, zipfh)
+
+            # …and extract its contents.
+            with ZipFile(zipfh) as zipfile:
+                safe_members = [
+                    (filename, member)
+                        for filename, member
+                         in ((PurePath(m.filename), m) for m in zipfile.infolist())
+                         if not filename.is_absolute()
+                        and os.path.pardir not in filename.parts ]
+
+                try:
+                    prefix = PurePath(os.path.commonpath([filename for filename, member in safe_members]))
+                except ValueError:
+                    prefix = PurePath("")
+
+                debug("common path prefix of archive members:", repr(prefix))
+                debug("mkdir:", self.path)
+
+                if not dry_run:
+                    self.path.mkdir(parents = True)
+
+                for filename, member in safe_members:
+                    if filename == prefix or filename in prefix.parents:
+                        continue
+
+                    member.filename = str(filename.relative_to(prefix)) \
+                                    + (os.path.sep if member.is_dir() else '')
+
+                    debug("extracting:", member.filename)
+
+                    if not dry_run:
+                        debug("extracted:", extracted := zipfile.extract(member, self.path))
+
+                        # Jeez.  This is making me question if we should be
+                        # using tarballs here instead.
+                        #   -trs, 10 Jan 2025
+                        if (member.create_system == 3               # Unix, to know what to expect in external_attr
+                        and (zipmode := member.external_attr >> 16) # Discard rightmost two bytes, leaving first two bytes (the file mode)
+                        and zipmode & S_IXUSR):
+                            oldmode = stat(extracted).st_mode
+                            newmode = (
+                                  oldmode
+                                | S_IXUSR                                # u+x
+                                | (S_IXGRP if oldmode & S_IRGRP else 0)  # g+x if g has r
+                                | (S_IXOTH if oldmode & S_IROTH else 0)) # o+x if o has r
+                            debug(f"chmod {oldmode:o} → {newmode:o}:", extracted)
+                            chmod(extracted, newmode)
+
+                print(f"Extracted {len(safe_members):,} files and directories to {str(self.path)!r}.")
+
+        self.setup_receipt = {
+            "name": self.name,
+            "version": self.version,
+            "url": str(self.url) }
+
+        with self.setup_receipt_path.open("w", encoding = "utf-8") as f:
+            json.dump(self.setup_receipt, f, indent = "  ")
+            print(file = f)
+
+        return True
+
+
+    def test_setup(self) -> SetupTestResults:
+        def test_compatibility() -> SetupTestResult:
+            msg = "nextstrain-pathogen.yaml declares `nextstrain run` compatibility"
+
+            try:
+                registration = read_pathogen_registration(self.registration_path)
+            except (OSError, yaml.YAMLError, ValueError):
+                if DEBUGGING:
+                    traceback.print_exc()
+                return msg + "\n(couldn't read registration)", False
+
+            try:
+                compatibility = registration["compatibility"]["nextstrain run"]
+            except (KeyError, IndexError, TypeError):
+                if DEBUGGING:
+                    traceback.print_exc()
+                return msg + "\n(couldn't find 'compatibility: nextstrain run: …' field)", False
+
+            return msg, bool(compatibility)
+
+        return [
+            ('downloaded',
+                self.path.is_dir()),
+
+            ('contains nextstrain-pathogen.yaml',
+                self.registration_path.is_file()),
+
+            test_compatibility(),
+        ]
+
+
+    def set_default_config(self) -> None:
+        """
+        Sets this version as the default for this pathogen.
+        """
+        config.set(f"pathogen {self.name}", "default_version", self.version)
+
+
+    def update(self) -> UpdateStatus:
+        """
+        Updates a specific version in-place or updates the default version to
+        the newest version.
+
+        An in-place update is attempted if this :cls:`PathogenVersion` was
+        instantiated with a version in the pathogen spec (i.e. not defaulted).
+        This is appropriate for a version that's mutable, like a branch name.
+        The process is roughly equivalent to `nextstrain setup --force NAME@VERSION`.
+
+        Otherwise, a default version update is attempted by setting up the
+        newest version and then making it the default.  This is appropriate for
+        a version that's immutable, like a tag name.  The process is roughly
+        equivalent to `nextstrain setup --set-default NAME`.
+        """
+        if self.spec.version:
+            new = PathogenVersion(self.name + "@" + self.version, new_setup = True)
+        else:
+            new = PathogenVersion(self.name, new_setup = True)
+
+        if new.version != self.version:
+            print(f"Updating from {str(self)!r} to {str(new)!r}…")
+            ok = new.setup()
+
+        elif new.url != self.url:
+            print(f"Updating {str(new)!r} in-place…")
+            ok = new.setup(force = True)
+
+        else:
+            assert new == self
+
+            if self.spec.version:
+                print(f"{str(self)!r} already up-to-date.")
+            else:
+                print(f"{self.name!r} already at newest version.")
+            print()
+
+            return True
+
+        # None of the update() routines for runners test their setups, but it
+        # makes sense to do so for pathogens.  Here's why:
+        #
+        # The Docker/Singularity/AWS Batch runtime checks focus on the
+        # machinery required to use the runtime image, but do not test the
+        # contents/correctness of the runtime image *itself*; they assume
+        # that's ok.  The pathogen checks OTOH solely test the
+        # contents/correctness of the pathogen itself; so it makes sense to
+        # check it after any change/update unlike the Docker checks.  The Conda
+        # runtime checks do both! (and so ostensibly should run after update
+        # too…)
+        #   -trs, 2 April 2025
+        #    see also <https://github.com/nextstrain/cli/pull/407#discussion_r1990288763>
+        if ok:
+            print(f"Checking setup…")
+            ok = print_and_check_setup_tests(new.test_setup())
+
+        if ok and not self.spec.version:
+            print(f"Setting default version to {str(new)!r}.")
+            new.set_default_config()
+
+            # XXX TODO SOON: Delete old version (self.path) at this point?  The
+            # runtimes delete old versions after update to recover disk space.
+            # Pathogens use a lot less space, but I think it's still worth it
+            # to tidy up?  OTOH, it seems more likely for pathogens that people
+            # will blindly update to see if there's anything new and then want
+            # to trial it/compare it against the old version (or immediately
+            # revert back if the new version breaks something).
+            #   -trs, 3 Feb 2025
+
+        return ok
+
+
+    @staticmethod
+    def encode_version_dir(version: str) -> str:
+        """
+        >>> PathogenVersion.encode_version_dir("1.2.3")
+        '1.2.3=GEXDELRT'
+
+        >>> PathogenVersion.encode_version_dir("abc/lmnop/xyz")
+        'abc-lmnop-xyz=MFRGGL3MNVXG64BPPB4XU==='
+        """
+        # Prefixing a munged version is solely for the benefit of humans
+        # looking at their filesystem.
+        version_munged = re.sub(r'[^A-Za-z0-9_.-]', '-', version)
+        version_b32 = b32encode(version.encode("utf-8")).decode("utf-8")
+        assert "=" not in version_munged
+        return version_munged + "=" + version_b32
+
+    @staticmethod
+    def decode_version_dir(fname: str) -> str:
+        """
+        >>> PathogenVersion.decode_version_dir(PathogenVersion.encode_version_dir("v42"))
+        'v42'
+
+        >>> PathogenVersion.decode_version_dir("1.2.3=GEXDELRT")
+        '1.2.3'
+
+        Munged version prefix for humans is ignored.
+
+        >>> PathogenVersion.decode_version_dir("x.y.z=GEXDELRT")
+        '1.2.3'
+        >>> PathogenVersion.decode_version_dir("=GEXDELRT")
+        '1.2.3'
+
+        Case-mangled names are still ok.
+
+        >>> PathogenVersion.decode_version_dir("1.2.3=gExDeLrT")
+        '1.2.3'
+        """
+        _, version_b32 = fname.split("=", 1)
+        return b32decode(version_b32, casefold = True).decode("utf-8")
+
+
+    def __str__(self) -> str:
+        return f"{self.name}@{self.version}"
+
+    def __repr__(self) -> str:
+        return f"<PathogenVersion {self!s} url={self.url!r} path={str(self.path)!r}>"
+
+    def __eq__(self, other) -> bool:
+        if self.__class__ != other.__class__:
+            return False
+
+        return self.name    == other.name \
+           and self.version == other.version \
+           and (self.url    == other.url or self.url is None or other.url is None)
+
+
+def every_pathogen_default_by_name(pathogens: Dict[str, Dict[str, PathogenVersion]] = None) -> Dict[str, PathogenVersion]:
+    """
+    Scans file system to return a dict of :cls:`PathogenVersion` objects,
+    representing pathogen default version setups, keyed by their name.
+
+    Sorted by name (case-insensitively).
+
+    To avoid a filesystem scan for consistency (and performance in the limit)
+    when it's been scanned already, the result of a previous call to
+    :func:`all_pathogen_versions_by_name` may be passed.
+    """
+    if pathogens is None:
+        pathogens = all_pathogen_versions_by_name()
+
+    # The `default_version in versions` check avoids a KeyError in the edge
+    # case of a configured default version that's not present on the
+    # filesystem.
+    return {
+        name: versions[default_version]
+            for name, versions in pathogens.items()
+             if (default_version := default_version_of(name, versions = list(versions.keys())))
+            and default_version in versions }
+
+
+def all_pathogen_versions_by_name() -> Dict[str, Dict[str, PathogenVersion]]:
+    """
+    Scans file system to return a two-level dict of :cls:`PathogenVersion`
+    objects, representing all pathogen version setups, keyed by their name then
+    version.
+
+    Sorted by name (case-insensitively) and version (PEP-440-compliant versions
+    (newest → oldest) first then other textual versions (A → Z and 0 → 9, by
+    parts)).
+
+    >>> from pprint import pp
+    >>> pp(all_pathogen_versions_by_name()) # doctest: +ELLIPSIS
+    {'with-implicit-default': {'1.2.3': <PathogenVersion with-implicit-default@1.2.3 ...>},
+     'with-no-implicit-default': {'4.5.6': <PathogenVersion with-no-implicit-default@4.5.6 ...>,
+                                  '1.2.3': <PathogenVersion with-no-implicit-default@1.2.3 ...>}}
+    """
+    return {
+        name: { v.version: v for v in versions }
+            for name, versions
+             in groupby(all_pathogen_versions(), lambda p: p.name) }
+
+
+def all_pathogen_versions() -> List[PathogenVersion]:
+    """
+    Scans file system to return a list of :cls:`PathogenVersion` objects
+    representing found setups.
+
+    Sorted by name (case-insensitively) and version (PEP-440-compliant versions
+    (newest → oldest) first then other textual versions (A → Z and 0 → 9, by
+    parts)).
+    """
+    if not PATHOGENS.exists():
+        return []
+
+    return [
+        PathogenVersion(pathogen_dir.name + "@" + version)
+            for pathogen_dir in sorted(PATHOGENS.iterdir(), key = lambda p: p.name.casefold())
+             if pathogen_dir.is_dir()
+            for version in versions_within(pathogen_dir) ]
+
+
+def pathogen_defaults(name: str) -> Tuple[Optional[PathogenVersion], Optional[PathogenVersion]]:
+    """
+    Returns a tuple of :cls:`PathogenVersion` objects (or ``None``)
+    representing the explicitly configured default for pathogen *name* (if any)
+    and the implicit default (if any).
+
+    Most code won't care about the distinction, but ``nextstrain setup`` does.
+    """
+    if configured_default := default_version_of(name, implicit = False):
+        # XXX TODO: Handle the edge case of a configured default version that
+        # no longer exists on the filesystem.  For now, the code below will
+        # raise a UserError (see also FileNotFoundError comments in
+        # PathogenVersion.__init__).  Precedence for warning and ignoring
+        # exists in nextstrain/cli/runner/__init__.py, FWIW.
+        #   -trs, 3 Feb 2025
+        #
+        # See also what every_pathogen_default_by_name() does.
+        #   -trs, 28 Mar 2025
+        configured_default = PathogenVersion(f"{name}@{configured_default}")
+    else:
+        configured_default = None
+
+    if configured_default:
+        default = configured_default
+    elif default := default_version_of(name, implicit = True):
+        default = PathogenVersion(f"{name}@{default}")
+    else:
+        default = None
+
+    return default, configured_default
+
+
+def default_version_of(name: str, implicit: bool = True, versions: List[str] = None) -> Optional[str]:
+    """
+    Returns the default version string for the pathogen *name*.
+
+    If the user config contains an explicit default, that value is returned.
+
+    >>> default_version_of("from-config")
+    'v1'
+
+    Otherwise, if *implicit* is ``True`` (the default), then the filesystem is
+    scanned for available versions of *name* and if there's only one setup, its
+    version is returned.
+
+    >>> default_version_of("with-implicit-default")
+    '1.2.3'
+    >>> default_version_of("with-implicit-default", implicit = False)
+    >>>
+    >>> default_version_of("with-no-implicit-default")
+    >>>
+
+    To avoid a filesystem scan for consistency (and performance in the limit)
+    when it's been scanned already, a list of string *versions* may be passed.
+    This is only used when no default is configured and *implicit* is ``True``.
+
+    >>> default_version_of("with-cached-versions", versions = ["one"])
+    'one'
+
+    >>> default_version_of("with-cached-versions", versions = ["one", "two"])
+    >>>
+
+    >>> default_version_of("from-config", versions = ["one", "two"])
+    'v1'
+
+    If no default version can be determined, ``None`` is returned.
+
+    >>> default_version_of("not-in-config")
+    >>>
+    >>> default_version_of("bogus")
+    >>>
+    """
+    assert name
+    default = config.get(f"pathogen {name}", "default_version")
+
+    # The "implicit default" behaviour below makes the code (in
+    # pathogen_defaults() above and in nextstrain/cli/setup.py) considerably
+    # more complicated.  It's tempting to ditch the behaviour to ditch the
+    # additional complexity.  But I think the implicit default also makes the
+    # `nextstrain setup` and `nextstrain run` user interfaces more humane.  If
+    # someone has only one version of a pathogen installed (as will be very
+    # common), why should they have to remember to specify --set-default at
+    # setup-time or the full version at run-time?  It would be annoying for the
+    # computer to tell them, "hey, what version of 'measles' did you mean?"
+    # when they only have one version of 'measles' installed!
+    #
+    # I dithered on this for a while, but I think it's worth taking on the
+    # behind-the-scenes complexity in order to make the user interface more
+    # compatible with human common sense.
+    #   -trs, 10 Jan 2025
+    #
+    # See also our long discussion of this (mostly captured) on a PR review
+    # thread: <https://github.com/nextstrain/cli/pull/407#discussion_r1990232730>
+    #   -trs, 7 April 2025
+    if not default and implicit:
+        if versions is None:
+            versions = versions_of(name)
+
+        if len(versions) == 1:
+            default = versions[0]
+
+    return default or None
+
+
+def versions_of(name: str) -> List[str]:
+    """
+    Scans the filesystem for setup versions of pathogen *name* and returns a
+    list of version strings.
+
+    Sorted as PEP-440-compliant versions (newest → oldest) then other textual
+    versions (A → Z and 0 → 9, by parts).
+
+    >>> versions_of("with-implicit-default")
+    ['1.2.3']
+
+    >>> versions_of("with-no-implicit-default")
+    ['4.5.6', '1.2.3']
+
+    >>> versions_of("bogus")
+    []
+    """
+    return versions_within(PATHOGENS / name)
+
+
+def versions_within(pathogen_dir: Path) -> List[str]:
+    """
+    Scans the filesystem for setup versions within *pathogen_dir* and returns a
+    list of version strings.
+
+    Sorted as PEP-440-compliant versions (newest → oldest) then other textual
+    versions (A → Z and 0 → 9, by parts).
+    """
+    if not pathogen_dir.exists():
+        return []
+
+    versions = [
+        parse_version_lax(PathogenVersion.decode_version_dir(d.name))
+            for d in pathogen_dir.iterdir()
+             if d.is_dir() ]
+
+    # Sort newest → oldest for normal versions (e.g. 4.5.6, 1.2.3) and A → Z
+    # for non-compliant versions (e.g. branch names, commit ids, arbitrary
+    # strings, etc.), with the latter always after the former.
+    compliant     = sorted(v for v in versions if v.compliant)
+    non_compliant = sorted(v for v in versions if not v.compliant)
+
+    return [v.original for v in [*reversed(compliant), *non_compliant]]
+
+
+def read_pathogen_registration(path: Path) -> Dict:
+    """
+    Reads a ``nextstrain-pathogen.yaml`` file at *path* and returns a dict of
+    its deserialized contents.
+    """
+    with path.open("r", encoding = "utf-8") as f:
+        registration = yaml.safe_load(f)
+
+    # XXX TODO SOON: Consider doing actual schema validation here in the
+    # future.
+    #   -trs, 12 Dec 2024
+    if not isinstance(registration, dict):
+        raise ValueError(f"pathogen registration not a dict (got a {type(registration).__name__}): {str(path)!r}")
+
+    return registration
+
+
+# XXX TODO SOON: This logic should probably move into nextstrain.org endpoints
+# (and start us down the road of a real Nextstrain pathogen registry).  That
+# would also give us insight into usage and allows us the flexibility to move
+# away from Git-based distribution in the future.
+#   -trs, 3 Feb 2025
+def github_repo_latest_ref(repo_name: str) -> Optional[str]:
+    """
+    Queries a GitHub *repo_name* to return the name of the highest version tag,
+    if any, otherwise the name of the default branch.
+    """
+    with requests.Session() as http:
+        response = http.get(f"https://api.github.com/repos/{urlquote(repo_name)}", headers = github_headers())
+
+        if response.status_code == 404:
+            return None
+        else:
+            response.raise_for_status()
+
+        repo = response.json()
+
+        tags_url = URL(repo["tags_url"])
+        tags_url = tags_url._replace(query = "per_page=100&" + tags_url.query)
+
+        tags = []
+
+        while tags_url:
+            response = http.get(str(tags_url), headers = github_headers())
+            response.raise_for_status()
+
+            tags += response.json()
+
+            tags_url = response.links.get("next", {}).get("url")
+
+        if tag_names := sorted([t["name"] for t in tags], key = parse_version_lax, reverse = True):
+            return tag_names[0]
+
+        return repo["default_branch"]
+
+
+def github_repo_ref_zipball_url(repo: str, ref: str) -> URL:
+    """
+    Queries a GitHub *repo* to resolve *ref* (any commit-ish) to a specific
+    commit id (SHA) and returns a URL to a ZIP file of the repo contents at
+    that commit.
+    """
+    with requests.Session() as http:
+        commit = http.get(f"https://api.github.com/repos/{urlquote(repo)}/commits/{urlquote(ref)}", headers = {**github_headers(), "Accept": "application/vnd.github.sha"})
+        commit.raise_for_status()
+
+        assert (sha := commit.text)
+
+    return URL(f"https://api.github.com/repos/{urlquote(repo)}/zipball/{urlquote(sha)}")
+
+
+def github_headers():
+    return {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }

--- a/nextstrain/cli/paths.py
+++ b/nextstrain/cli/paths.py
@@ -35,6 +35,9 @@ NEXTSTRAIN_HOME = from_env("NEXTSTRAIN_HOME", HOME / ".nextstrain/")
 # Path to runtime data dirs
 RUNTIMES = from_env("NEXTSTRAIN_RUNTIMES", NEXTSTRAIN_HOME / "runtimes/")
 
+# Path to pathogen workflow data dirs
+PATHOGENS = from_env("NEXTSTRAIN_PATHOGENS", NEXTSTRAIN_HOME / "pathogens/")
+
 # Path to our config file
 CONFIG = from_env("NEXTSTRAIN_CONFIG", NEXTSTRAIN_HOME / "config")
 

--- a/nextstrain/cli/rst/__init__.py
+++ b/nextstrain/cli/rst/__init__.py
@@ -50,6 +50,7 @@ PREAMBLE = """
 .. role:: option(literal)
 .. role:: envvar(literal)
 .. role:: kbd(literal)
+.. role:: file(literal)
 .. default-role:: command-invocation
 """
 

--- a/nextstrain/cli/runner/__init__.py
+++ b/nextstrain/cli/runner/__init__.py
@@ -23,15 +23,22 @@ all_runners: List[RunnerModule] = [
 
 all_runners_by_name = dict((runner_name(r), r) for r in all_runners)
 
-default_runner = docker
-configured_runner = config.get("core", "runner")
+def runner_defaults():
+    default_runner = docker
+    configured_runner = None
 
-if configured_runner:
-    try:
-        default_runner = runner_module(configured_runner)
-    except ValueError:
-        warn("WARNING: Default runner from config file (%s) is invalid.  Using %s.\n"
-            % (configured_runner, runner_name(default_runner)))
+    if configured := config.get("core", "runner"):
+        try:
+            configured_runner = runner_module(configured)
+        except ValueError:
+            warn("WARNING: Default runner from config file (%s) is invalid.  Using %s.\n"
+                % (configured, runner_name(default_runner)))
+        else:
+            default_runner = configured_runner
+
+    return default_runner, configured_runner
+
+default_runner, configured_runner = runner_defaults()
 
 
 RunnerExec: TypeAlias = List[Union[str, EllipsisType]]

--- a/nextstrain/cli/runner/ambient.py
+++ b/nextstrain/cli/runner/ambient.py
@@ -37,7 +37,7 @@ import os
 import shutil
 from subprocess import CalledProcessError
 from typing import Iterable
-from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
+from ..types import Env, SetupStatus, SetupTestResults, UpdateStatus
 from ..util import capture_output, exec_or_return
 
 
@@ -59,14 +59,14 @@ def run(opts, argv, working_volume = None, extra_env: Env = {}, cpus: int = None
     return exec_or_return(argv, extra_env)
 
 
-def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus:
+def setup(dry_run: bool = False, force: bool = False) -> SetupStatus:
     """
     Not supported.
     """
     return None
 
 
-def test_setup() -> RunnerTestResults:
+def test_setup() -> SetupTestResults:
     def runnable(*argv) -> bool:
         try:
             capture_output(argv)
@@ -92,7 +92,7 @@ def set_default_config() -> None:
     pass
 
 
-def update() -> RunnerUpdateStatus:
+def update() -> UpdateStatus:
     """
     Not supported.  Updating the ambient environment isn't reasonably possible.
     """

--- a/nextstrain/cli/runner/ambient.py
+++ b/nextstrain/cli/runner/ambient.py
@@ -35,10 +35,12 @@ Once you've installed dependencies, proceed with ``nextstrain setup ambient``.
 
 import os
 import shutil
+import sys
 from subprocess import CalledProcessError
-from typing import Iterable
-from ..types import Env, SetupStatus, SetupTestResults, UpdateStatus
-from ..util import capture_output, exec_or_return
+from typing import Iterable, cast
+from .. import config
+from ..types import Env, RunnerModule, SetupStatus, SetupTestResults, UpdateStatus
+from ..util import capture_output, exec_or_return, runner_name
 
 
 def register_arguments(parser) -> None:
@@ -87,9 +89,9 @@ def test_setup() -> SetupTestResults:
 
 def set_default_config() -> None:
     """
-    No-op.
+    Sets ``core.runner`` to this runner's name (``ambient``).
     """
-    pass
+    config.set("core", "runner", runner_name(cast(RunnerModule, sys.modules[__name__])))
 
 
 def update() -> UpdateStatus:

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -80,16 +80,17 @@ defaults set by `config file variables`_.
 import botocore.exceptions
 import os
 import shlex
+import sys
 from datetime import datetime
 from pathlib import Path
 from signal import signal, Signals, SIGINT
 from sys import exit, stdin
 from textwrap import dedent
 from time import sleep, time
-from typing import Iterable, Optional
+from typing import Iterable, Optional, cast
 from uuid import uuid4
-from ...types import Env, SetupStatus, SetupTestResults, UpdateStatus
-from ...util import colored, prose_list, warn
+from ...types import Env, RunnerModule, SetupStatus, SetupTestResults, UpdateStatus
+from ...util import colored, prose_list, runner_name, warn
 from ... import config
 from .. import docker
 from . import jobs, s3
@@ -582,9 +583,9 @@ def test_setup() -> SetupTestResults:
 
 def set_default_config() -> None:
     """
-    No-op.
+    Sets ``core.runner`` to this runner's name (``aws-batch``).
     """
-    pass
+    config.set("core", "runner", runner_name(cast(RunnerModule, sys.modules[__name__])))
 
 
 def update() -> UpdateStatus:

--- a/nextstrain/cli/runner/aws_batch/__init__.py
+++ b/nextstrain/cli/runner/aws_batch/__init__.py
@@ -88,7 +88,7 @@ from textwrap import dedent
 from time import sleep, time
 from typing import Iterable, Optional
 from uuid import uuid4
-from ...types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
+from ...types import Env, SetupStatus, SetupTestResults, UpdateStatus
 from ...util import colored, prose_list, warn
 from ... import config
 from .. import docker
@@ -559,14 +559,14 @@ def generate_run_id() -> str:
     return str(uuid4())
 
 
-def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus:
+def setup(dry_run: bool = False, force: bool = False) -> SetupStatus:
     """
     Not supported.
     """
     return None
 
 
-def test_setup() -> RunnerTestResults:
+def test_setup() -> SetupTestResults:
     """
     Check that necessary AWS resources exist.
     """
@@ -587,7 +587,7 @@ def set_default_config() -> None:
     pass
 
 
-def update() -> RunnerUpdateStatus:
+def update() -> UpdateStatus:
     """
     Not supported.  Updating the AWS Batch runtime isn't meaningful.
     """

--- a/nextstrain/cli/runner/aws_batch/s3.py
+++ b/nextstrain/cli/runner/aws_batch/s3.py
@@ -188,6 +188,15 @@ def download_workdir(remote_workdir: S3Object, workdir: Path, patterns: List[str
                         mtime = zipinfo_mtime(member)
                         utime(extracted, (mtime, mtime))
 
+                        # XXX TODO: Preserve/restore Unix mode (e.g. executable
+                        # bit).  Currently not handled by this routine, though
+                        # we could if need be; see nextstrain/cli/pathogens.py
+                        # for an example.  It doesn't seem necessary for
+                        # pathogen builds, however, as 1) we've gone this long
+                        # without it and 2) pathogen workflows aren't producing
+                        # executables as their primary output.
+                        #   -trs, 10 Feb 2025
+
 
 def walk(path: Path, excluded: PathMatcher = lambda x: False) -> Generator[Path, None, None]:
     """

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -77,15 +77,17 @@ import re
 import requests
 import shutil
 import subprocess
+import sys
 import tarfile
 import traceback
 from pathlib import Path, PurePosixPath
-from typing import Iterable, NamedTuple, Optional
+from typing import Iterable, NamedTuple, Optional, cast
 from urllib.parse import urljoin, quote as urlquote
+from .. import config
 from ..errors import InternalError
 from ..paths import RUNTIMES
-from ..types import Env, SetupStatus, SetupTestResults, UpdateStatus
-from ..util import capture_output, colored, exec_or_return, parse_version_lax, setup_tests_ok, test_rosetta_enabled, warn
+from ..types import Env, RunnerModule, SetupStatus, SetupTestResults, UpdateStatus
+from ..util import capture_output, colored, exec_or_return, parse_version_lax, runner_name, setup_tests_ok, test_rosetta_enabled, warn
 
 
 RUNTIME_ROOT = RUNTIMES / "conda/"
@@ -473,9 +475,9 @@ def test_support() -> SetupTestResults:
 
 def set_default_config() -> None:
     """
-    No-op.
+    Sets ``core.runner`` to this runner's name (``conda``).
     """
-    pass
+    config.set("core", "runner", runner_name(cast(RunnerModule, sys.modules[__name__])))
 
 
 def update() -> UpdateStatus:

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -84,8 +84,8 @@ from typing import Iterable, NamedTuple, Optional
 from urllib.parse import urljoin, quote as urlquote
 from ..errors import InternalError
 from ..paths import RUNTIMES
-from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
-from ..util import capture_output, colored, exec_or_return, parse_version_lax, runner_tests_ok, test_rosetta_enabled, warn
+from ..types import Env, SetupStatus, SetupTestResults, UpdateStatus
+from ..util import capture_output, colored, exec_or_return, parse_version_lax, setup_tests_ok, test_rosetta_enabled, warn
 
 
 RUNTIME_ROOT = RUNTIMES / "conda/"
@@ -168,7 +168,7 @@ def run(opts, argv, working_volume = None, extra_env: Env = {}, cpus: int = None
     return exec_or_return(argv, {**extra_env, **EXEC_ENV})
 
 
-def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus:
+def setup(dry_run: bool = False, force: bool = False) -> SetupStatus:
     if not setup_micromamba(dry_run, force):
         return False
 
@@ -389,7 +389,7 @@ def micromamba(*args, add_prefix: bool = True) -> None:
         raise InternalError(f"Error running {argv!r}") from err
 
 
-def test_setup() -> RunnerTestResults:
+def test_setup() -> SetupTestResults:
     def which_finds_our(cmd) -> bool:
         # which() checks executability and also handles PATHEXT, e.g. the
         # ".exe" extension on Windows, which is why we don't just naively test
@@ -422,7 +422,7 @@ def test_setup() -> RunnerTestResults:
 
     yield from support
 
-    if not runner_tests_ok(support):
+    if not setup_tests_ok(support):
         return
 
     elif not PREFIX_BIN.exists():
@@ -443,7 +443,7 @@ def test_setup() -> RunnerTestResults:
                 which_finds_our("auspice") and runnable("auspice", "--version"))
 
 
-def test_support() -> RunnerTestResults:
+def test_support() -> SetupTestResults:
     def supported_os() -> bool:
         machine = platform.machine()
         system = platform.system()
@@ -478,7 +478,7 @@ def set_default_config() -> None:
     pass
 
 
-def update() -> RunnerUpdateStatus:
+def update() -> UpdateStatus:
     """
     Update all installed packages with Micromamba.
     """

--- a/nextstrain/cli/runner/conda.py
+++ b/nextstrain/cli/runner/conda.py
@@ -79,15 +79,13 @@ import shutil
 import subprocess
 import tarfile
 import traceback
-from functools import partial
-from packaging.version import Version, InvalidVersion
 from pathlib import Path, PurePosixPath
 from typing import Iterable, NamedTuple, Optional
 from urllib.parse import urljoin, quote as urlquote
 from ..errors import InternalError
 from ..paths import RUNTIMES
 from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
-from ..util import capture_output, colored, exec_or_return, runner_tests_ok, test_rosetta_enabled, warn
+from ..util import capture_output, colored, exec_or_return, parse_version_lax, runner_tests_ok, test_rosetta_enabled, warn
 
 
 RUNTIME_ROOT = RUNTIMES / "conda/"
@@ -632,68 +630,8 @@ def latest_package_label_version(channel: str, package: str, label: str) -> Opti
     label_files = (file for file in response.json() if label in file.get("labels", []))
     # Default '0-dev' should be the lowest version according to PEP440
     # See https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
-    latest_file: dict = max(label_files, default={}, key=lambda file: parse_version(file.get('version', '0-dev')))
+    latest_file: dict = max(label_files, default={}, key=lambda file: parse_version_lax(file.get('version', '0-dev')))
     return latest_file.get("version")
-
-
-def parse_version(version: str) -> Version:
-    """
-    Parse *version* into a PEP-440-compliant :cls:`Version` object, by hook or
-    by crook.
-
-    If *version* isn't already PEP-440 compliant, then it is parsed as a
-    PEP-440 local version label after replacing with ``.`` any characters not
-    matching ``a-z``, ``A-Z``, ``0-9``, ``.``, ``_``, or ``-``.  The comparison
-    semantics for local version labels amount to a string- and integer-based
-    comparison by parts ("segments"), which is super good enough for our
-    purposes here.  The full local version identifier produced for versions
-    parsed in this way always contains a public version identifier component of
-    ``0.dev0`` so it compares lowest against other public version identifiers.
-
-    >>> parse_version("1.2.3")
-    <Version('1.2.3')>
-    >>> parse_version("1.2.3-nope")
-    <Version('0.dev0+1.2.3.nope')>
-    >>> parse_version("20221019T172207Z")
-    <Version('0.dev0+20221019t172207z')>
-    >>> parse_version("@invalid+@")
-    <Version('0.dev0+invalid')>
-    >>> parse_version("not@@ok")
-    <Version('0.dev0+not.ok')>
-    >>> parse_version("20221019T172207Z") < parse_version("20230525T143814Z")
-    True
-    """
-    try:
-        return Version(version)
-    except InvalidVersion:
-        # Per PEP-440
-        #
-        # > …local version labels MUST be limited to the following set of
-        # > permitted characters:
-        # >
-        # >   ASCII letters ([a-zA-Z])
-        # >   ASCII digits ([0-9])
-        # >   periods (.)
-        # >
-        # > Local version labels MUST start and end with an ASCII letter or
-        # > digit.
-        #
-        # and
-        #
-        # > With a local version, in addition to the use of . as a separator of
-        # > segments, the use of - and _ is also acceptable. The normal form is
-        # > using the . character.
-        #
-        # and empty segments (x..z) aren't allowed either.
-        #
-        # c.f. <https://peps.python.org/pep-0440/#local-version-identifiers>
-        #      <https://peps.python.org/pep-0440/#local-version-segments>
-        remove_invalid_start_end_chars = partial(re.sub, r'^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$', '')
-        replace_invalid_with_separators = partial(re.sub, r'[^a-zA-Z0-9._-]+', '.')
-
-        as_local_segment = lambda v: replace_invalid_with_separators(remove_invalid_start_end_chars(v))
-
-        return Version(f"0.dev0+{as_local_segment(version)}")
 
 
 class PackageSpec(NamedTuple):

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -86,7 +86,7 @@ from textwrap import dedent
 from typing import Iterable, List
 from .. import config, env
 from ..errors import UserError
-from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerTestResultStatus, RunnerUpdateStatus
+from ..types import Env, SetupStatus, SetupTestResults, SetupTestResultStatus, UpdateStatus
 from ..util import warn, colored, capture_output, exec_or_return, split_image_name, test_rosetta_enabled
 from ..volume import NamedVolume
 from ..__version__ import __version__
@@ -245,7 +245,7 @@ def mount_point(volume: NamedVolume) -> PurePosixPath:
     return PurePosixPath("/nextstrain", volume.name)
 
 
-def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus:
+def setup(dry_run: bool = False, force: bool = False) -> SetupStatus:
     if not setup_image(dry_run, force):
         return False
 
@@ -274,7 +274,7 @@ def setup_image(dry_run: bool = False, force: bool = False) -> bool:
     return True
 
 
-def test_setup() -> RunnerTestResults:
+def test_setup() -> SetupTestResults:
     def test_run():
         try:
             status = subprocess.run(
@@ -291,7 +291,7 @@ def test_setup() -> RunnerTestResults:
         desired = 2 * GiB
 
         msg = 'containers have access to >%.0f GiB of memory' % (desired / GiB)
-        status: RunnerTestResultStatus = ...
+        status: SetupTestResultStatus = ...
 
         if image_exists():
             def int_or_none(x):
@@ -332,7 +332,7 @@ def test_setup() -> RunnerTestResults:
         minimum_tag = IMAGE_FEATURE.compatible_auspice.value
 
         msg = 'image is new enough for this CLI version'
-        status: RunnerTestResultStatus = ...
+        status: SetupTestResultStatus = ...
 
         repository, tag = split_image_name(DEFAULT_IMAGE)
 
@@ -385,14 +385,14 @@ def set_default_config() -> None:
     config.setdefault("docker", "image", latest_build_image(DEFAULT_IMAGE))
 
 
-def update() -> RunnerUpdateStatus:
+def update() -> UpdateStatus:
     """
     Pull down the latest Docker image build and prune old image versions.
     """
     return _update()
 
 
-def _update(dry_run: bool = False) -> RunnerUpdateStatus:
+def _update(dry_run: bool = False) -> UpdateStatus:
     current_image = DEFAULT_IMAGE
     latest_image  = latest_build_image(current_image)
 

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -79,15 +79,16 @@ import json
 import requests
 import shutil
 import subprocess
+import sys
 from enum import Enum
 from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import Iterable, List
+from typing import Iterable, List, cast
 from .. import config, env
 from ..errors import UserError
-from ..types import Env, SetupStatus, SetupTestResults, SetupTestResultStatus, UpdateStatus
-from ..util import warn, colored, capture_output, exec_or_return, split_image_name, test_rosetta_enabled
+from ..types import Env, RunnerModule, SetupStatus, SetupTestResults, SetupTestResultStatus, UpdateStatus
+from ..util import warn, colored, capture_output, exec_or_return, runner_name, split_image_name, test_rosetta_enabled
 from ..volume import NamedVolume
 from ..__version__ import __version__
 
@@ -379,9 +380,12 @@ def test_setup() -> SetupTestResults:
 
 def set_default_config() -> None:
     """
+    Sets ``core.runner`` to this runner's name (``docker``).
+
     Sets ``docker.image``, if it isn't already set, to the latest ``build-*``
     image.
     """
+    config.set("core", "runner", runner_name(cast(RunnerModule, sys.modules[__name__])))
     config.setdefault("docker", "image", latest_build_image(DEFAULT_IMAGE))
 
 

--- a/nextstrain/cli/runner/singularity.py
+++ b/nextstrain/cli/runner/singularity.py
@@ -85,16 +85,17 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from functools import lru_cache
 from packaging.version import Version, InvalidVersion
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, cast
 from urllib.parse import urlsplit
 from .. import config
 from ..errors import UserError
 from ..paths import RUNTIMES
-from ..types import Env, SetupStatus, SetupTestResults, UpdateStatus
-from ..util import capture_output, colored, exec_or_return, split_image_name, warn
+from ..types import Env, RunnerModule, SetupStatus, SetupTestResults, UpdateStatus
+from ..util import capture_output, colored, exec_or_return, runner_name, split_image_name, warn
 from . import docker
 
 flatten = itertools.chain.from_iterable
@@ -345,9 +346,12 @@ def test_setup() -> SetupTestResults:
 
 def set_default_config() -> None:
     """
+    Sets ``core.runner`` to this runner's name (``singularity``).
+
     Sets ``singularity.image``, if it isn't already set, to the latest
     ``build-*`` image.
     """
+    config.set("core", "runner", runner_name(cast(RunnerModule, sys.modules[__name__])))
     config.setdefault("singularity", "image", latest_build_image(DEFAULT_IMAGE))
 
 

--- a/nextstrain/cli/runner/singularity.py
+++ b/nextstrain/cli/runner/singularity.py
@@ -93,7 +93,7 @@ from urllib.parse import urlsplit
 from .. import config
 from ..errors import UserError
 from ..paths import RUNTIMES
-from ..types import Env, RunnerSetupStatus, RunnerTestResults, RunnerUpdateStatus
+from ..types import Env, SetupStatus, SetupTestResults, UpdateStatus
 from ..util import capture_output, colored, exec_or_return, split_image_name, warn
 from . import docker
 
@@ -273,7 +273,7 @@ def run(opts, argv, working_volume = None, extra_env: Env = {}, cpus: int = None
     ], extra_env)
 
 
-def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus:
+def setup(dry_run: bool = False, force: bool = False) -> SetupStatus:
     if not setup_image(dry_run, force):
         return False
 
@@ -309,7 +309,7 @@ def setup_image(dry_run: bool = False, force: bool = False) -> bool:
     return True
 
 
-def test_setup() -> RunnerTestResults:
+def test_setup() -> SetupTestResults:
     def test_run():
         try:
             capture_output([
@@ -351,7 +351,7 @@ def set_default_config() -> None:
     config.setdefault("singularity", "image", latest_build_image(DEFAULT_IMAGE))
 
 
-def update() -> RunnerUpdateStatus:
+def update() -> UpdateStatus:
     """
     Download and convert the latest Docker runtime image into a local
     Singularity image.
@@ -361,7 +361,7 @@ def update() -> RunnerUpdateStatus:
     return _update()
 
 
-def _update(dry_run: bool = False) -> RunnerUpdateStatus:
+def _update(dry_run: bool = False) -> UpdateStatus:
     current_image = DEFAULT_IMAGE
     latest_image  = latest_build_image(current_image)
 

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -6,7 +6,7 @@ import argparse
 import builtins
 import sys
 from pathlib import Path
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Protocol, Tuple, Union, TYPE_CHECKING
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Protocol, Tuple, Union, TYPE_CHECKING, runtime_checkable
 # TODO: Use typing.TypeAlias once Python 3.10 is the minimum supported version.
 from typing_extensions import TypeAlias
 
@@ -55,6 +55,7 @@ S3Bucket = Any
 S3Object = Any
 
 
+@runtime_checkable
 class RunnerModule(Protocol):
     @staticmethod
     def register_arguments(parser: argparse.ArgumentParser) -> None: ...

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -40,13 +40,13 @@ EnvValue = Union[str, None]
 
 Options = argparse.Namespace
 
-RunnerSetupStatus = Optional[bool]
+SetupStatus = Optional[bool]
 
-RunnerTestResults = Iterable['RunnerTestResult']
-RunnerTestResult  = Tuple[str, 'RunnerTestResultStatus']
-RunnerTestResultStatus: TypeAlias = Union[bool, None, EllipsisType]
+SetupTestResults = Iterable['SetupTestResult']
+SetupTestResult  = Tuple[str, 'SetupTestResultStatus']
+SetupTestResultStatus: TypeAlias = Union[bool, None, EllipsisType]
 
-RunnerUpdateStatus = Optional[bool]
+UpdateStatus = Optional[bool]
 
 # Cleaner-reading type annotations for boto3 S3 objects, which maybe can be
 # improved later.  The actual types are generated at runtime in
@@ -69,16 +69,16 @@ class RunnerModule(Protocol):
         ...
 
     @staticmethod
-    def setup(dry_run: bool = False, force: bool = False) -> RunnerSetupStatus: ...
+    def setup(dry_run: bool = False, force: bool = False) -> SetupStatus: ...
 
     @staticmethod
-    def test_setup() -> RunnerTestResults: ...
+    def test_setup() -> SetupTestResults: ...
 
     @staticmethod
     def set_default_config() -> None: ...
 
     @staticmethod
-    def update() -> RunnerUpdateStatus: ...
+    def update() -> UpdateStatus: ...
 
     @staticmethod
     def versions() -> Iterable[str]: ...

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -8,7 +8,7 @@ import sys
 from functools import partial
 from importlib.metadata import distribution as distribution_info, PackageNotFoundError
 from typing import Any, Callable, Iterable, Literal, Mapping, List, Optional, Sequence, Tuple, Union, overload
-from packaging.version import parse as parse_version
+from packaging.version import Version, InvalidVersion, parse as parse_version_strict
 from pathlib import Path, PurePath
 from shlex import quote as shquote
 from shutil import which
@@ -263,8 +263,8 @@ def new_version_available():
         intended for development and testing but can also be used to disable
         the update check by setting the value to 0.
     """
-    this_version   = parse_version(__version__)
-    latest_version = parse_version(os.environ.get("NEXTSTRAIN_CLI_LATEST_VERSION") or fetch_latest_pypi_version("nextstrain-cli"))
+    this_version   = parse_version_strict(__version__)
+    latest_version = parse_version_strict(os.environ.get("NEXTSTRAIN_CLI_LATEST_VERSION") or fetch_latest_pypi_version("nextstrain-cli"))
 
     return str(latest_version) if latest_version > this_version else None
 
@@ -692,3 +692,65 @@ def prose_list(iterable: Iterable[str], conjunction: str = "or") -> str:
         return ", ".join([*values[:-1], f"{conjunction} " + values[-1]])
     else:
         return f" {conjunction} ".join(values)
+
+
+def parse_version_lax(version: str) -> Version:
+    """
+    Parse *version* into a PEP-440-compliant :cls:`Version` object, by hook or
+    by crook.  Dubbed "lax" because a non-compliant *version* will not raise an
+    exception (in contrast to :func:`parse_version_strict`) but will produce a
+    :cls:`Version` object with reasonably useful comparison behaviour.
+
+    If *version* isn't already PEP-440 compliant, then it is parsed as a
+    PEP-440 local version label after replacing with ``.`` any characters not
+    matching ``a-z``, ``A-Z``, ``0-9``, ``.``, ``_``, or ``-``.  The comparison
+    semantics for local version labels amount to a string- and integer-based
+    comparison by parts ("segments"), which is super good enough for our
+    purposes here.  The full local version identifier produced for versions
+    parsed in this way always contains a public version identifier component of
+    ``0.dev0`` so it compares lowest against other public version identifiers.
+
+    >>> parse_version_lax("1.2.3")
+    <Version('1.2.3')>
+    >>> parse_version_lax("1.2.3-nope")
+    <Version('0.dev0+1.2.3.nope')>
+    >>> parse_version_lax("20221019T172207Z")
+    <Version('0.dev0+20221019t172207z')>
+    >>> parse_version_lax("@invalid+@")
+    <Version('0.dev0+invalid')>
+    >>> parse_version_lax("not@@ok")
+    <Version('0.dev0+not.ok')>
+    >>> parse_version_lax("20221019T172207Z") < parse_version_lax("20230525T143814Z")
+    True
+    """
+    try:
+        return Version(version)
+    except InvalidVersion:
+        # Per PEP-440
+        #
+        # > …local version labels MUST be limited to the following set of
+        # > permitted characters:
+        # >
+        # >   ASCII letters ([a-zA-Z])
+        # >   ASCII digits ([0-9])
+        # >   periods (.)
+        # >
+        # > Local version labels MUST start and end with an ASCII letter or
+        # > digit.
+        #
+        # and
+        #
+        # > With a local version, in addition to the use of . as a separator of
+        # > segments, the use of - and _ is also acceptable. The normal form is
+        # > using the . character.
+        #
+        # and empty segments (x..z) aren't allowed either.
+        #
+        # c.f. <https://peps.python.org/pep-0440/#local-version-identifiers>
+        #      <https://peps.python.org/pep-0440/#local-version-segments>
+        remove_invalid_start_end_chars = partial(re.sub, r'^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$', '')
+        replace_invalid_with_separators = partial(re.sub, r'[^a-zA-Z0-9._-]+', '.')
+
+        as_local_segment = lambda v: replace_invalid_with_separators(remove_invalid_start_end_chars(v))
+
+        return Version(f"0.dev0+{as_local_segment(version)}")

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -593,14 +593,14 @@ def glob_match(path: Union[str, Path, PurePath], patterns: Union[str, Sequence[s
 
 def setup_tests_ok(tests: SetupTestResults) -> bool:
     """
-    Returns True iff none of a runner's ``test_setup()`` results failed.
+    Returns True iff none of a runner's or pathogen's ``test_setup()`` results failed.
     """
     return False not in [result for test, result in tests]
 
 
 def print_and_check_setup_tests(tests: SetupTestResults) -> bool:
     """
-    Iterates through and prints runner test results.
+    Iterates through and prints a runner's or pathogen's setup test results.
     Returns True if there are no failures.
     """
     success = partial(colored, "green")
@@ -692,6 +692,18 @@ def prose_list(iterable: Iterable[str], conjunction: str = "or") -> str:
         return ", ".join([*values[:-1], f"{conjunction} " + values[-1]])
     else:
         return f" {conjunction} ".join(values)
+
+
+def request_list(response: requests.Response, initial_indent = "    ", redirect_indent = "  ⮡ ") -> str:
+    """
+    Formats the requested URLs (including redirects) that led to *response* as
+    a multi-line text-snippet.
+
+    Intended for use in user-facing messages.
+    """
+    return "\n".join(
+        initial_indent + (redirect_indent * i) + r.url
+            for i, r in enumerate([*response.history, response]) )
 
 
 def parse_version_lax(version: str) -> 'LaxVersion':

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -16,7 +16,7 @@ from textwrap import dedent, indent
 from wcmatch.glob import globmatch, GLOBSTAR, EXTGLOB, BRACE, MATCHBASE, NEGATE, NEGATEALL, REALPATH
 from .__version__ import __version__
 from .debug import debug
-from .types import RunnerModule, RunnerTestResults, RunnerTestResultStatus
+from .types import RunnerModule, SetupTestResults, SetupTestResultStatus
 
 
 NO_COLOR = bool(
@@ -591,14 +591,14 @@ def glob_match(path: Union[str, Path, PurePath], patterns: Union[str, Sequence[s
     return globmatch(path, patterns, flags = GLOBSTAR | BRACE | EXTGLOB | MATCHBASE | NEGATE | NEGATEALL | (REALPATH if root else 0), root_dir = root)
 
 
-def runner_tests_ok(tests: RunnerTestResults) -> bool:
+def setup_tests_ok(tests: SetupTestResults) -> bool:
     """
     Returns True iff none of a runner's ``test_setup()`` results failed.
     """
     return False not in [result for test, result in tests]
 
 
-def print_and_check_runner_tests(tests: RunnerTestResults) -> bool:
+def print_and_check_setup_tests(tests: SetupTestResults) -> bool:
     """
     Iterates through and prints runner test results.
     Returns True if there are no failures.
@@ -632,10 +632,10 @@ def print_and_check_runner_tests(tests: RunnerTestResults) -> bool:
 
         print(status.get(result, str(result)) + ":", formatted_description)
 
-    return runner_tests_ok(results)
+    return setup_tests_ok(results)
 
 
-def test_rosetta_enabled(msg: str = "Rosetta 2 is enabled") -> RunnerTestResults:
+def test_rosetta_enabled(msg: str = "Rosetta 2 is enabled") -> SetupTestResults:
     """
     Check if Rosetta 2 is enabled (installed and active) on macOS aarch64
     systems.
@@ -643,7 +643,7 @@ def test_rosetta_enabled(msg: str = "Rosetta 2 is enabled") -> RunnerTestResults
     if (platform.system(), platform.machine()) != ("Darwin", "arm64"):
         return
 
-    status: RunnerTestResultStatus = ... # unknown
+    status: SetupTestResultStatus = ... # unknown
 
     try:
         subprocess.run(

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         "packaging",
         "pyjwt[crypto] >=2.0.0",
         "pyparsing >=3.0.0",
+        "pyyaml >=5.3.1",
         "requests",
         "typing_extensions >=3.7.4",
         "wcmatch >=6.0",

--- a/tests/data/home/config
+++ b/tests/data/home/config
@@ -1,1 +1,4 @@
 # Nextstrain CLI config file used in tests, via NEXTSTRAIN_HOME=tests/data/home/.
+
+[pathogen from-config]
+default_version = v1

--- a/tests/version.cram
+++ b/tests/version.cram
@@ -2,10 +2,18 @@ Cram setup.
 
     $ source "$TESTDIR"/env
 
-Version.
+Version command.
 
     $ nextstrain version
     Nextstrain CLI [0-9]+[.][0-9]+[.][0-9]+\S*  (re)
 
     $ python3 -Xnextstrain-cli-is-standalone -m nextstrain.cli version
+    Nextstrain CLI [0-9]+[.][0-9]+[.][0-9]+\S* \(standalone\) (re)
+
+Conventional --version flag.
+
+    $ nextstrain --version
+    Nextstrain CLI [0-9]+[.][0-9]+[.][0-9]+\S*  (re)
+
+    $ python3 -Xnextstrain-cli-is-standalone -m nextstrain.cli --version
     Nextstrain CLI [0-9]+[.][0-9]+[.][0-9]+\S* \(standalone\) (re)


### PR DESCRIPTION
_based on <https://github.com/nextstrain/cli/pull/419>_

Adds a new command, [`nextstrain run`](https://nextstrain--407.org.readthedocs.build/projects/cli/en/407/commands/run/), to run (compatible) pathogen workflows workflows in a more managed way with easier update paths, without the need for user-facing Git, with support for multiple versions, and with support for concurrent-but-separate analyses via the same workflow.

Supported by changes to

- [`nextstrain setup`](https://nextstrain--407.org.readthedocs.build/projects/cli/en/407/commands/setup/) to obtain and set up specific versions of pathogens
- [`nextstrain update`](https://nextstrain--407.org.readthedocs.build/projects/cli/en/407/commands/update/) to keep pathogens up-to-date
- [`nextstrain version`](https://nextstrain--407.org.readthedocs.build/projects/cli/en/407/commands/version/) to report on pathogen versions set up

Try out setting up a pathogen and running it yourself. First, install `nextstrain` built from this PR:

Linux/macOS:

```bash
curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/"$(uname -s)" | bash -s pr-build/407
```

Windows:

```powershell
Invoke-Expression "& { $(Invoke-RestMethod https://nextstrain.org/cli/installer/windows) } pr-build/407"
```

At the moment, the only compatible pathogen is measles at my [not-yet-finished demo/prototype branch](https://github.com/nextstrain/measles/pull/55). Avian flu should not be far behind, though.

Some commands to try:

```console
$ nextstrain setup measles@trs/workflows-as-programs
$ nextstrain version --pathogens
$ nextstrain version --pathogens --verbose
$ nextstrain run measles ingest /tmp/measles-ingest
$ tree -l /tmp/measles-ingest
$ nextstrain run measles phylogenetic /tmp/measles-phylo
$ tree -l /tmp/measles-phylo
$ nextstrain view /tmp/measles-phylo
```

Note that on any of the updated command documentation pages linked above you can press `d` to see a colorized diff against the latest non-PR version.

There's a lot of functionality (and polish) here and elsewhere still todo to fully realize the sweeping goals of [workflows-as-programs](https://github.com/nextstrain/public/issues/1), but this is a fully-usable first piece of the puzzle that can stand on its own for now.

## Checklist

- [x] Changelog for workflows-as-programs
- [x] Reconsider "implicit default" behaviour; replace it with "default is
      first setup" behaviour instead?  For runtimes too, not just pathogens.
      <https://github.com/nextstrain/cli/pull/407#discussion_r1996156775>
- [x] Example of URL to a pathogen ZIP file
      <https://github.com/nextstrain/cli/pull/407#discussion_r1987785013>
- [x] Review wording in `--help` and docs: "pathogen" → "pathogen repository"?
- [x] Review wording in `--help` and docs: "pathogen" vs. "workflow" / "pathogen workflow"
      <https://github.com/nextstrain/cli/pull/407#discussion_r1988064649>
- [x] Checks pass