### PR TITLE
dev: Explicitly point Read The Docs at our Sphinx configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,7 @@ build:
   tools:
     python: "3.10"
 sphinx:
+  configuration: doc/conf.py
   builder: dirhtml
 python:
   install:


### PR DESCRIPTION
Previously we relied on RTD's auto-detection of the Sphinx configuration file.  That's being deprecated for good on 20 January 2025, with temporary brownouts starting on 6 Jan.¹

¹ <https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
