### PR TITLE
Report CI failures through GitHub issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,7 +401,8 @@ jobs:
       - test-standalone
       - doc
       - release
-    uses: nextstrain/.github/.github/workflows/report-failure.yaml
+    # FIXME: drop the branch tag after merging https://github.com/nextstrain/.github/pull/121
+    uses: nextstrain/.github/.github/workflows/report-failure.yaml@victorlin/report-failure
     with:
       failure: ${{ contains(needs.*.result, 'failure') }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,3 +389,29 @@ jobs:
       - run: ./devel/create-github-release "${{github.ref_name}}" dist/* nextstrain-cli-*-standalone-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  report-failure:
+    if: ${{ always() && github.ref_name == github.event.repository.default_branch }}
+    needs:
+      - lint
+      - test-source
+      - build-dist
+      - build-standalone
+      - test-dist
+      - test-standalone
+      - doc
+      - release
+    uses: nextstrain/.github/.github/workflows/report-failure.yaml
+    with:
+      failure: ${{ contains(needs.*.result, 'failure') }}
+
+      # The condition evaluates to true when all results are 'success',
+      # 'cancelled', or 'skipped'¹. This is not ideal, since a workflow that is
+      # cancelled before there are any successes will still signal a success to
+      # this job, however the chance of that happening should be very low given
+      # that this is job is conditioned on the default branch.
+      # ¹ <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#jobs-context>
+      success: ${{ !contains(needs.*.result, 'failure') }}
+      title: CI failure
+    secrets:
+      token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}


### PR DESCRIPTION
## Description of proposed changes

Report failures for all jobs but `write-install-commands`, which is more of an intermediate helper than something to report errors for.

If this gets noisy for any particular job, it can be ignored by removing the job id from the dependency list.

## Related issue(s)

Closes #412 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] [Installation failure = issue created](https://github.com/victorlin/nextstrain-cli/actions/runs/13213217932/job/36889350168#step:4:57)
    - Preview: https://github.com/victorlin/nextstrain-cli/issues/5
- [x] [Installation failure with 1 open issue = no action](https://github.com/victorlin/nextstrain-cli/actions/runs/13213217932/job/36889364578#step:4:56)
- [x] [Installation success with 2 open issues = error](https://github.com/victorlin/nextstrain-cli/actions/runs/13213217932/job/36889383666#step:4:56)
- [x] [Installation success with 1 open issue = issue closed](https://github.com/victorlin/nextstrain-cli/actions/runs/13213284687/job/36889496256#step:4:57)
- [x] [Installation success with no open issue = no action](https://github.com/victorlin/nextstrain-cli/actions/runs/13213284687/job/36889505921#step:4:56)
- [ ] Merge https://github.com/nextstrain/.github/pull/121
- [ ] Drop ad12f213a8bcae7b94a193956ea2dff6713a4013

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
