### PR TITLE
Gracefully handle IPv6 sockaddrs when Python's compiled without IPv6 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* Fixed a rare but possible error case in `nextstrain view` and `nextstrain
+  login` when running under a copy of Python with IPv6 disabled on a system
+  with IPv6 enabled.  In such situations, IPv6 addresses will now be ignored.
+  ([#415](https://github.com/nextstrain/cli/pull/415))
+
 
 # 8.5.4 (1 November 2024)
 

--- a/nextstrain/cli/net.py
+++ b/nextstrain/cli/net.py
@@ -32,7 +32,17 @@ def resolve_host(host: str, family: AddressFamily = AF_UNSPEC) -> Set[Union[IPv4
     depending on the local IP stack and DNS records for the named host.  A
     specific address family can be chosen by providing *family*.
     """
+    # The isinstance() checks filter out IPv6 addresses when Python lacks
+    # support.¹  They also make it clear by inspection that our argument types
+    # check-out even though we're using a "type: ignore" comment because it's
+    # not clear to the type checker.
+    #   -trs, 11 Feb 2025
+    #
+    # ¹ See <https://github.com/python/cpython/issues/60412>
+    #   and <https://github.com/python/cpython/issues/128546>.
     return {
-        ip_address(getnameinfo(sockaddr, NI_NUMERICHOST)[0])
+        ip_address(getnameinfo(sockaddr, NI_NUMERICHOST)[0]) # type: ignore
             for _, _, _, _, sockaddr
-             in getaddrinfo(host, None, family = family) }
+             in getaddrinfo(host, None, family = family)
+             if isinstance(sockaddr[0], str)
+            and isinstance(sockaddr[1], int) }


### PR DESCRIPTION
Skip 'em instead of erroring.  Brought to attention by a typeshed update for the standard library that adds tuple[int, bytes] as a potential sockaddr value from getaddrinfo() when running Python compiled with --disable-ipv6 on a system that enables IPv6.  Such a value reflects the underlying libc sockaddr struct and is not directly usable without bypassing the disabling of IPv6.  The stdlib's type signature doesn't reflect the full constraints on actual return values—i.e. under what conditions each value type is actually returned—so the type checker is under-informed and requires some muzzling.

Resolves <https://github.com/nextstrain/cli/issues/411>.

