### PR TITLE
net: Don't consider a host that we can't resolve as having a loopback address

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@ development source code and as such may not be routinely kept up to date.
   with IPv6 enabled.  In such situations, IPv6 addresses will now be ignored.
   ([#415](https://github.com/nextstrain/cli/pull/415))
 
+* An authentication callback URL containing an unresolvable hostname is no
+  longer considered to have a loopback (local-only) address, i.e. is not
+  considered safe/suitable for use.
+  ([#416](https://github.com/nextstrain/cli/pull/416))
+
 
 # 8.5.4 (1 November 2024)
 

--- a/nextstrain/cli/net.py
+++ b/nextstrain/cli/net.py
@@ -21,6 +21,9 @@ def is_loopback(host: Optional[str]) -> Optional[bool]:
     except gaierror:
         return None
 
+    if not ips:
+        return None
+
     return all(ip.is_loopback for ip in ips)
 
 


### PR DESCRIPTION
Our is_loopback() implements three-valued logic (True, False, None) but all() implements boolean logic, so we need to handle the empty case ourself.  Oops!

Noticed while testing an IPv6-only host against a Python with IPv6 disabled, which made it unresolvable.  See "Gracefully handle IPv6 sockaddrs when Python's compiled without IPv6 support" (06e830b).

