### PR TITLE
runner.aws_batch: Bump minimum Docker image required for overlays on AWS Batch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,10 +36,10 @@ below.
 
 * AWS Batch builds now support development overlays such as [`--augur`][] and
   [`--auspice`][].  To use this functionality, you'll need at least
-  `nextstrain/base:build-20250304T041009Z` or newer of the Nextstrain Docker
+  `nextstrain/base:build-20250321T184358Z` or newer of the Nextstrain Docker
   runtime image.  Compatibility of the runtime image is checked automatically
   when overlays are used with AWS Batch.
-  ([#419][])
+  ([#419][], [#423](https://github.com/nextstrain/cli/pull/423))
 
 [`--augur`]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/build/#cmdoption-nextstrain-build-augur
 [`--auspice`]: https://docs.nextstrain.org/projects/cli/en/__NEXT__/commands/build/#cmdoption-nextstrain-build-auspice

--- a/nextstrain/cli/runner/docker.py
+++ b/nextstrain/cli/runner/docker.py
@@ -114,7 +114,7 @@ class IMAGE_FEATURE(Enum):
 
     # AWS Batch: support for volume overlays (i.e. ../ in archive members and
     # file overwriting) in ZIP extraction.
-    aws_batch_overlays = "build-20250304T041009Z"
+    aws_batch_overlays = "build-20250321T184358Z"
 
 
 def register_arguments(parser) -> None:


### PR DESCRIPTION
There is now no caveat¹ of AWS Batch overlays being partial while Docker and Singularity overlays are complete.  Overlays are complete and behave the same across containerized runtimes.

Spurred by conversation in review² and realizing, after some tinkering, that it would not take too much extra effort after all to implement in the image entrypoint.

¹ As mentioned in "runner.aws_batch: Support overlay volumes (e.g.
  --augur)" (99168ac).

² <https://github.com/nextstrain/cli/pull/419#discussion_r1982432118>

## Checklist

- [x] [Image build](https://github.com/nextstrain/docker-base/actions/runs/13998734807) completes successfully
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
