### PR TITLE
GH workflows: Remove ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,7 +283,6 @@ jobs:
         # fresh CI machines are not readily available, however, since
         # pre-installation is convenient for builds.
         include:
-          - { os: ubuntu-20.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04, target: x86_64-unknown-linux-gnu }
           - { os: macos-13,     target: x86_64-apple-darwin }

--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13


### PR DESCRIPTION
## Description of proposed changes

Remove ubuntu-20.04 since GH Actions has officially ended support for it on 2025-04-15.

<https://github.com/actions/runner-images/issues/11101>

## Related issue(s)

Following up to https://github.com/nextstrain/.github/issues/122#issuecomment-2651855979

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Standalone installers workflow](https://github.com/nextstrain/cli/actions/runs/14524310503)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
