### PR TITLE
util: Update PyPI URL to respect 301 Permanent Redirect

### DIFF
--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -273,7 +273,7 @@ def fetch_latest_pypi_version(project):
     """
     Return the latest version of the given project from PyPi.
     """
-    return requests.get("https://pypi.python.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")
+    return requests.get("https://pypi.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")
 
 
 def capture_output(argv, extra_env: Mapping = {}):


### PR DESCRIPTION
When using mitmproxy to observe other HTTP traffic during other development, I noticed that the pypi.python.org URL we were using was responding with a 301 to pypi.org.  It'd be sweet as if requests locally remembered 301s (like a browser does), but it doesn't, and I'm not about to add that feature right now.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
