### PR TITLE
util: Fetch our own latest version via nextstrain.org instead of pypi.org

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,13 @@ our broader "workflows as programs" endeavor.
 
 [User-Agent header]: https://en.wikipedia.org/wiki/User-Agent_header
 
+* When checking for upgrades for Nextstrain CLI itself during `nextstrain
+  check-setup` and `nextstrain update`, the latest version is now fetched from
+  nextstrain.org instead of pypi.org.  This gives us insights into usage and
+  also more flexibility to shift how we're releasing and distributing this
+  project.
+  ([#434](https://github.com/nextstrain/cli/pull/434))
+
 
 # 9.0.0 (24 March 2025)
 

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -17,6 +17,7 @@ from . import requests
 from .__version__ import __version__
 from .debug import debug
 from .types import RunnerModule, SetupTestResults, SetupTestResultStatus
+from .url import NEXTSTRAIN_DOT_ORG, URL
 
 
 NO_COLOR = bool(
@@ -279,16 +280,16 @@ def new_version_available():
         the update check by setting the value to 0.
     """
     this_version   = parse_version_strict(__version__)
-    latest_version = parse_version_strict(os.environ.get("NEXTSTRAIN_CLI_LATEST_VERSION") or fetch_latest_pypi_version("nextstrain-cli"))
+    latest_version = parse_version_strict(os.environ.get("NEXTSTRAIN_CLI_LATEST_VERSION") or fetch_latest_version())
 
     return str(latest_version) if latest_version > this_version else None
 
 
-def fetch_latest_pypi_version(project):
+def fetch_latest_version():
     """
-    Return the latest version of the given project from PyPi.
+    Return the latest version of ourselves from nextstrain.org.
     """
-    return requests.get("https://pypi.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")
+    return requests.get(str(URL("/cli", NEXTSTRAIN_DOT_ORG)), headers = {"Accept": "application/json"}).json().get("latest_version", "")
 
 
 def capture_output(argv, extra_env: Mapping = {}):

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -288,7 +288,7 @@ def fetch_latest_pypi_version(project):
     """
     Return the latest version of the given project from PyPi.
     """
-    return requests.get("https://pypi.python.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")
+    return requests.get("https://pypi.org/pypi/%s/json" % project).json().get("info", {}).get("version", "")
 
 
 def capture_output(argv, extra_env: Mapping = {}):


### PR DESCRIPTION
This gives us insights into usage and also more flexibility to shift how we're releasing and distributing it.

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/1160>

Replaces/incorporates #433.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
