### PR TITLE
runner.conda: Allow overriding of subdir selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,24 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Development
+
+* `nextstrain setup conda` and `nextstrain update conda` now respect an
+  optional `NEXTSTRAIN_CONDA_OVERRIDE_SUBDIR` environment variable that when
+  set overrides the default behaviour of detecting the best Conda subdir that's
+  usable for the platform.
+
+  This may be used, for example, to force the use of the x86\_64 architecture
+  (`osx-64` subdir) on macOS hardware that's natively the `aarch64` (aka arm64,
+  Apple Silicon, M1/M2/…) architecture (`osx-arm64` subdir):
+
+      NEXTSTRAIN_CONDA_OVERRIDE_SUBDIR=osx-64 nextstrain setup conda
+
+  The variable must be set for every invocation of `nextstrain setup conda` or
+  `nextstrain update conda`, otherwise the default behaviour will apply and the
+  subdir in use by the runtime may be automatically switched.
+  ([#437](https://github.com/nextstrain/cli/pull/437))
+
 
 # 10.1.0 (19 May 2025)
 

--- a/nextstrain/cli/rst/__init__.py
+++ b/nextstrain/cli/rst/__init__.py
@@ -232,7 +232,7 @@ def doc_url(target: str) -> str:
     return project_url.rstrip("/") + "/" + path_url.lstrip("/")
 
 
-class Reader(docutils.readers.standalone.Reader):
+class Reader(docutils.readers.standalone.Reader): # pyright: ignore[reportUntypedBaseClass]
     def get_transforms(self):
         return [*super().get_transforms(), MarkEmbeddedHyperlinkReferencesAnonymous]
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,7 +3,9 @@
   "include": ["nextstrain"],
   "ignore": [
     "nextstrain/cli/markdown.py",
-    "nextstrain/cli/rst/sphinx.py"
+    "nextstrain/cli/rst/sphinx.py",
+    "/**/node_modules/pyright/dist/typeshed-fallback/",
+    "c:/**/node_modules/pyright/dist/typeshed-fallback/"
   ],
   "reportMissingImports": false,
   "reportMissingModuleSource": true,


### PR DESCRIPTION
It seems like it will prove useful to be able to force a particular subdir for both testing/development and as a workaround to issues with specific subdirs on platforms that support more than one (e.g. forcing osx-64 instead of osx-arm64, if osx-arm64 is broken in some way).

I thought about implementing this along with my recent subdir handling changes, but I thought maybe YAGNI and deferred.  The slew of issues recently uncovered with osx-arm64 though made me reconsider and JFDI.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
