### PR TITLE
dev: Update Windows GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
             target: aarch64-apple-darwin
             exe: nextstrain
 
-          - os: windows-2019
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             exe: nextstrain.exe
 
@@ -290,8 +290,8 @@ jobs:
           - { os: macos-15,     target: x86_64-apple-darwin }
           - { os: macos-14,     target: aarch64-apple-darwin }
           - { os: macos-15,     target: aarch64-apple-darwin }
-          - { os: windows-2019, target: x86_64-pc-windows-msvc }
           - { os: windows-2022, target: x86_64-pc-windows-msvc }
+          - { os: windows-2025, target: x86_64-pc-windows-msvc }
 
     runs-on: ${{matrix.os}}
     defaults:

--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -40,8 +40,8 @@ jobs:
           - macos-13
           - macos-14      # (aarch64)
           - macos-15      # (aarch64)
-          - windows-2019
           - windows-2022
+          - windows-2025
 
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
## Description of proposed changes

Windows Server 2019 has been scheduled for deprecation and will be [removed by end of June](https://github.com/actions/runner-images/issues/12045).  I moved the build job to the next oldest version, Windows Server 2022.

Windows Server 2025 was [released in December 2024](https://github.com/actions/runner-images/issues/11228), so test on it.

## Related issue(s)

Closes https://github.com/nextstrain/.github/issues/131

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
