### PR TITLE
Ignore environment settings in pathogen repo request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,18 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* `nextstrain setup <pathogen>` will no longer attempt to use a local netrc file
+  for authentication. This fixes a bug which caused pathogen repo download to
+  fail when the local netrc file contained an expired GitHub authentication
+  token.
+
+  Previous behavior allowed setup of private repositories using the
+  fully-specified `<name>@<version>=<url>` format, however support for that was
+  unintentional and has been removed by this change.
+  ([#444](https://github.com/nextstrain/cli/issues/444))
+
 ## Documentation
 
 * This changelog is [now

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -16,6 +16,19 @@ development source code and as such may not be routinely kept up to date.
 (v-next)=
 ## __NEXT__
 
+(v-next-bug-fixes)=
+### Bug fixes
+
+* `nextstrain setup <pathogen>` will no longer attempt to use a local netrc file
+  for authentication. This fixes a bug which caused pathogen repo download to
+  fail when the local netrc file contained an expired GitHub authentication
+  token.
+
+  Previous behavior allowed setup of private repositories using the
+  fully-specified `<name>@<version>=<url>` format, however support for that was
+  unintentional and has been removed by this change.
+  ([#444](https://github.com/nextstrain/cli/issues/444))
+
 (v-next-documentation)=
 ### Documentation
 

--- a/nextstrain/cli/pathogens.py
+++ b/nextstrain/cli/pathogens.py
@@ -324,7 +324,9 @@ class PathogenVersion:
                 self.setup_receipt_path.unlink(missing_ok = True)
 
         try:
-            response = requests.get(str(self.url), headers = {"Accept": "application/zip, */*"}, stream = True)
+            with requests.Session() as session:
+                session.trust_env = False
+                response = session.get(str(self.url), headers = {"Accept": "application/zip, */*"}, stream = True)
             response.raise_for_status()
 
         except requests.exceptions.ConnectionError as err:


### PR DESCRIPTION
## Description of proposed changes

The default behavior of the requests library is to [automatically honor](https://github.com/psf/requests/blob/v2.32.4/README.md#supported-features--bestpractices) the user's netrc file. We do not (1) need or (2) want this behavior in the case of downloading a pathogen repo because (1) the API endpoint works fine without authentication and (2) any expired credentials will cause the request to fail when it would've succeeded without the credentials.

I chose not to set trust_env to False on all Sessions because the default [honors](https://github.com/psf/requests/blob/v2.32.4/src/requests/sessions.py#L768-L769) `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` env vars, a feature [used](https://github.com/nextstrain/docs.nextstrain.org/blob/ab09ba2577b0333c42dbff2e5b293013c226ab9a/src/reference/ca-certificates.rst#requests-module) by other requests.

## Related issue(s)

Closes #444

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
