### PR TITLE
dev: Properly stage changes to MyST-formatted changelog

### DIFF
--- a/devel/release
+++ b/devel/release
@@ -5,6 +5,7 @@ devel="$(dirname "$0")"
 repo="$devel/.."
 version_file="$repo/nextstrain/cli/__version__.py"
 changes_file="$repo/CHANGES.md"
+myst_changes_file="$repo/doc/changes.md"
 
 main() {
     local version
@@ -106,16 +107,19 @@ update-changelog() {
     # for use in doc URLs that should point to the released version.
     perl -pi -e "s/__NEXT__/$new_version/g if /^# \\Q$new_version/ ... /^# /" "$changes_file"
 
-    # Remove the __NEXT__ heading and the sentence «The "__NEXT__" heading
-    # below…» for the next commit, but leave the working tree untouched.
-    perl -0p -e '
-        s/^# __NEXT__\n\n\n//m;
-        s/\s*The "__NEXT__" heading below .+?\.//s;
-    ' "$changes_file" | git-add-stdin-as "$changes_file"
-
     # Generate and stage the MyST-formatted changelog for commit
     "$devel"/generate-changes-doc
-    git add "$repo/doc/changes.md"
+
+    # Remove references to __NEXT__ for the next commit, but leave the working
+    # tree untouched.
+    for f in "$changes_file" "$myst_changes_file"; do
+        perl -0p -e '
+            s/^\(v-next\)=\n//m;
+            s/^## __NEXT__\n\n\n//m;
+            s/^# __NEXT__\n\n\n//m;
+            s/\s*The "__NEXT__" heading below .+?\.//s;
+        ' "$f" | git-add-stdin-as "$f"
+    done
 }
 
 git-add-stdin-as() {
@@ -154,7 +158,7 @@ unreleased-version() {
     # Add +git local part to mark any further development
     "$devel"/update-version "$unreleased_version"
 
-    git add "$version_file" "$changes_file"
+    git add "$version_file" "$changes_file" "$myst_changes_file"
     git commit -m "dev: Bump version to $unreleased_version"
 }
 


### PR DESCRIPTION
## Description of proposed changes

The previous PR #447 added the command to regenerate the MyST-formatted changelog, however it did not stage the changes in the same fashion as the other changelog file, so the generated commits ended up being out of sync. I've tested locally to check that it's fixed now.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Closes #446

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] ~Update changelog~ entry already added

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
