### PR TITLE
Remove Pyright rule exception

### DIFF
--- a/nextstrain/cli/rst/__init__.py
+++ b/nextstrain/cli/rst/__init__.py
@@ -232,7 +232,7 @@ def doc_url(target: str) -> str:
     return project_url.rstrip("/") + "/" + path_url.lstrip("/")
 
 
-class Reader(docutils.readers.standalone.Reader): # pyright: ignore[reportUntypedBaseClass]
+class Reader(docutils.readers.standalone.Reader):
     def get_transforms(self):
         return [*super().get_transforms(), MarkEmbeddedHyperlinkReferencesAnonymous]
 


### PR DESCRIPTION
## Description of proposed changes

This is no longer needed with Pyright 1.1.403, which added a type definition for docutils.readers.standalone.Reader.

<https://github.com/microsoft/pyright/commit/aa3492da54f045e4abb52e816a0f919426cbad8d>

## Related issue(s)

This should fix failing CI.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] ~Update changelog~ N/A, dev change

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
