### PR TITLE
runner.aws_batch: Download .snakemake/storage/ too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,15 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* Snakemake's storage support downloaded files (stored in `.snakemake/storage/`)
+  are now downloaded from AWS Batch builds by default.
+
+  The runtime image used must be at least `nextstrain/base:build-20250721T201347Z`
+  for these Snakemake storage files to be available for download from the AWS
+  Batch job.
+  ([#460](https://github.com/nextstrain/cli/pull/460))
 
 # 10.2.1.post1 (1 July 2025)
 

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -16,6 +16,16 @@ development source code and as such may not be routinely kept up to date.
 (v-next)=
 ## __NEXT__
 
+(v-next-improvements)=
+### Improvements
+
+* Snakemake's storage support downloaded files (stored in `.snakemake/storage/`)
+  are now downloaded from AWS Batch builds by default.
+
+  The runtime image used must be at least `nextstrain/base:build-20250721T201347Z`
+  for these Snakemake storage files to be available for download from the AWS
+  Batch job.
+  ([#460](https://github.com/nextstrain/cli/pull/460))
 
 (v10-2-1-post1)=
 ## 10.2.1.post1 (1 July 2025)

--- a/nextstrain/cli/runner/aws_batch/s3.py
+++ b/nextstrain/cli/runner/aws_batch/s3.py
@@ -141,8 +141,21 @@ def download_workdir(remote_workdir: S3Object, workdir: Path, patterns: List[str
         ".snakemake/log/",
 
         # …and the input/output metadata Snakemake tracks (akin to mtimes,
-        # which we also preserve).
+        # which we also preserve)…
         ".snakemake/metadata/",
+
+        # …and the remote files downloaded via Snakemake's storage support.
+        # Note this is the default path used by Snakemake, but the storage path
+        # is configurable via `--local-storage-prefix`.¹ So if someone configures
+        # the storage path to a custom path within `.snakemake`, e.g. `.snakemake/foo`,
+        # then it would not be available in their downloaded workdir.
+        # I'm not even sure it's possible to configure the path in entrypoint-aws-batch
+        # for the docker-base image, so I've added a warning against using the
+        # Snakemake option when using aws-batch runtimes.
+        #   -Jover, 18 July 2025
+        #
+        # ¹ <https://github.com/snakemake/snakemake/blob/v9.6.3/src/snakemake/cli.py#L1456-L1462>
+        ".snakemake/storage/",
     ])
 
     if patterns:


### PR DESCRIPTION
## Description of proposed changes

When using Snakemakes storage support to download remote files, Snakemake stores  the downloaded files in `.snakemake/storage` by default. This allows users to  keep the remote files that were downloaded during the build on AWS Batch.

Note that the storage path is configurable via Snakemake's  `--local-storage-prefix`.¹ So if someone configures the storage path to a custom  path within `.snakemake`, e.g. `.snakemake/foo`, then it would not be available  in their downloaded workdir. I'm not even sure it's possible to configure the path in entrypoint-aws-batch for the docker-base image, so I've added a warning against using the Snakemake option if using the aws-batch runtime.

Resolves https://github.com/nextstrain/cli/issues/453
Depends on https://github.com/nextstrain/docker-base/pull/259

¹ <https://github.com/snakemake/snakemake/blob/v9.6.3/src/snakemake/cli.py#L1456-L1462>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
