### PR TITLE
util: Account for non-default standalone installation paths in suggested update command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,12 @@ development source code and as such may not be routinely kept up to date.
   no longer result in a 404 error if `<version>` includes a slash and it is a
   valid version specifier. ([#459](https://github.com/nextstrain/cli/pull/459))
 
+* When a standalone installation of Nextstrain CLI suggests a command to run to
+  update itself, that command now takes into account non-default installation
+  paths so that the new version is installed to the same place as the current
+  version.
+  ([#474](https://github.com/nextstrain/cli/pull/474))
+
 # 10.2.1.post1 (1 July 2025)
 
 _See also changes in 10.2.1 which was an unreleased version._

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -39,6 +39,12 @@ development source code and as such may not be routinely kept up to date.
   no longer result in a 404 error if `<version>` includes a slash and it is a
   valid version specifier. ([#459](https://github.com/nextstrain/cli/pull/459))
 
+* When a standalone installation of Nextstrain CLI suggests a command to run to
+  update itself, that command now takes into account non-default installation
+  paths so that the new version is installed to the same place as the current
+  version.
+  ([#474](https://github.com/nextstrain/cli/pull/474))
+
 (v10-2-1-post1)=
 ## 10.2.1.post1 (1 July 2025)
 

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -235,15 +235,16 @@ def standalone_installation_path() -> Optional[Path]:
 
 def standalone_installer(version: str) -> str:
     system = platform.system()
+    destination = str(standalone_installation_path() or "")
 
     if system == "Linux":
-        return f"curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash -s {shquote(version)}"
+        return f"curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | DESTINATION={shquote(destination)} bash -s {shquote(version)}"
 
     elif system == "Darwin":
-        return f"curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash -s {shquote(version)}"
+        return f"curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | DESTINATION={shquote(destination)} bash -s {shquote(version)}"
 
     elif system == "Windows":
-        return 'Invoke-Expression "& { $(Invoke-RestMethod https://nextstrain.org/cli/installer/windows) } %s"' % shquote(version)
+        return '$env:DESTINATION=%s; Invoke-Expression "& { $(Invoke-RestMethod https://nextstrain.org/cli/installer/windows) } %s"' % (shquote(destination), shquote(version))
 
     else:
         raise RuntimeError(f"unknown system {system!r}")


### PR DESCRIPTION
Sets DESTINATION to the installation path we're running under so the new version is installed to the same place, rather than the default path.

This muddies the commands but makes them behave better, which is more important.  Particularly since soon we'll offer to run these commands automatically for the user.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
