### PR TITLE
Revert "Ignore environment settings in pathogen repo request"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,15 @@ supported Python version is always bundled with `nextstrain`.
   no longer result in a 404 error if `<version>` includes a slash and it is a
   valid version specifier. ([#459](https://github.com/nextstrain/cli/pull/459))
 
+* Reverting changes made in 10.2.1, `nextstrain setup <pathogen>` and
+  `nextstrain update <pathogen>` will once again attempt to use a local netrc
+  file for authentication when downloading pathogen source URLs.  This also
+  reinstates support in those cases for configuring outgoing network proxies
+  and CA certificate trust stores via environment variables.  Support for
+  private repositories is not unintentional and is something we intend to
+  provide.
+  ([#478](https://github.com/nextstrain/cli/issues/478))
+
 # 10.2.1.post1 (1 July 2025)
 
 _See also changes in 10.2.1 which was an unreleased version._

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -50,6 +50,15 @@ supported Python version is always bundled with `nextstrain`.
   no longer result in a 404 error if `<version>` includes a slash and it is a
   valid version specifier. ([#459](https://github.com/nextstrain/cli/pull/459))
 
+* Reverting changes made in 10.2.1, `nextstrain setup <pathogen>` and
+  `nextstrain update <pathogen>` will once again attempt to use a local netrc
+  file for authentication when downloading pathogen source URLs.  This also
+  reinstates support in those cases for configuring outgoing network proxies
+  and CA certificate trust stores via environment variables.  Support for
+  private repositories is not unintentional and is something we intend to
+  provide.
+  ([#478](https://github.com/nextstrain/cli/issues/478))
+
 (v10-2-1-post1)=
 ## 10.2.1.post1 (1 July 2025)
 

--- a/nextstrain/cli/pathogens.py
+++ b/nextstrain/cli/pathogens.py
@@ -345,9 +345,7 @@ class PathogenVersion:
                 self.setup_receipt_path.unlink(missing_ok = True)
 
         try:
-            with requests.Session() as session:
-                session.trust_env = False
-                response = session.get(str(self.url), headers = {"Accept": "application/zip, */*"}, stream = True)
+            response = requests.get(str(self.url), headers = {"Accept": "application/zip, */*"}, stream = True)
             response.raise_for_status()
 
         except requests.exceptions.ConnectionError as err:


### PR DESCRIPTION
This reverts commit e042a0ff890279bb389e869bbe990fd362da52fa.

We need to maintain "trust_env" support.

Proxy and CA certificate trust store settings provided via environment variables are crucial for outgoing network access in many tightly-controlled environments, like governmental networks.  They are necessary for _all_ requests, not just some requests.  We want places like CDC (a known user) to be able to use `nextstrain setup` and `nextstrain update`.

netrc is less crucial—it's less used—but it is a longstanding way to provide static credentials for remote hosts, and it can be reasonably expected to work.  We _do_ intend to support private pathogen repos, and netrc currently provides a means for that without embedding credentials into the pathogen source URL.

We can address the issue of invalid credentials causing confusing issues with better error handling instead.

Resolves: <https://github.com/nextstrain/cli/issues/468>
Unresolves: <https://github.com/nextstrain/cli/issues/444>
Related-to: <https://github.com/nextstrain/cli/pull/445>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
