### PR TITLE
Hint at invalid credentials when handling 401/403 errors during pathogen download

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,14 @@ supported Python version is always bundled with `nextstrain`.
   Batch job.
   ([#460](https://github.com/nextstrain/cli/pull/460))
 
+* When `nextstrain setup <pathogen>` and `nextstrain update <pathogen>`
+  encounter an authentication error downloading from pathogen source URLs, the
+  error message now includes a hint, if applicable, noting the presence of
+  netrc-provided credentials and possible resolutions.  This aids in resolving
+  errors arising from stale GitHub credentials present in some users' netrc
+  files (as managed by older versions of the GitHub CLI, `gh`).
+  ([#479](https://github.com/nextstrain/cli/issues/479))
+
 ## Bug fixes
 
 * `nextstrain setup <pathogen>@<version>` and `nextstrain update <pathogen>@<version>`

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -43,6 +43,14 @@ supported Python version is always bundled with `nextstrain`.
   Batch job.
   ([#460](https://github.com/nextstrain/cli/pull/460))
 
+* When `nextstrain setup <pathogen>` and `nextstrain update <pathogen>`
+  encounter an authentication error downloading from pathogen source URLs, the
+  error message now includes a hint, if applicable, noting the presence of
+  netrc-provided credentials and possible resolutions.  This aids in resolving
+  errors arising from stale GitHub credentials present in some users' netrc
+  files (as managed by older versions of the GitHub CLI, `gh`).
+  ([#479](https://github.com/nextstrain/cli/issues/479))
+
 (v-next-bug-fixes)=
 ### Bug fixes
 


### PR DESCRIPTION
Since netrc credentials are automatically and silently added, they may be unknown to the user.  Note their presence and suggest solutions in a hint following the error.  We do not automatically retry without credentials because they may be intended by (and known to) the user.

Ideally this sort of error handling is implemented at a higher (e.g. within nextstrain.cli.run()) or lower (e.g. within nextstrain.cli.requests.Session) level in the call stack so that ~all requests benefit from it, not just the single request targeted here. I'm leaving that for future work, though, as a) that's a more extensive change and b) we expect this specific request to be more affected by stale netrc credentials due to the combination of requests for api.github.com and old versions of the gh CLI.

Resolves: <https://github.com/nextstrain/cli/issues/444>
Related-to: <https://github.com/nextstrain/cli/pull/478>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
