### PR TITLE
run: Resolve workflow names using pathogen registration, if available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,34 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Improvements
+
+* `nextstrain run` now resolves workflow names by looking in the pathogen
+  registration (`nextstrain-pathogen.yaml`) for an explicitly registered path.
+  If no path is registered for a workflow, `nextstrain run` still falls back to
+  using the workflow name for the workflow path.
+
+  This allows for workflow names that are not also directory paths within the
+  pathogen source, which is useful for pathogens that are structured
+  non-conventionally for one reason or another.  The decoupling of workflow
+  names from paths also means that the workflow can be relocated within the
+  pathogen repo without breaking the name (i.e. the external interface to the
+  workflow).
+
+  As an example, the following workflow registration:
+
+  ```yaml
+  workflows:
+    phylogenetic:
+      path: .
+      compatibility:
+        nextstrain run: yes
+  ```
+
+  would allow invocation of a `phylogenetic` workflow located at the top-level
+  of the pathogen source, such as in [zika-tutorial](https://github.com/nextstrain/zika-tutorial).
+  ([#481](https://github.com/nextstrain/cli/pull/481))
+
 
 # 10.3.0 (26 September 2025)
 

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -16,6 +16,35 @@ development source code and as such may not be routinely kept up to date.
 (v-next)=
 ## __NEXT__
 
+(v-next-improvements)=
+### Improvements
+
+* `nextstrain run` now resolves workflow names by looking in the pathogen
+  registration (`nextstrain-pathogen.yaml`) for an explicitly registered path.
+  If no path is registered for a workflow, `nextstrain run` still falls back to
+  using the workflow name for the workflow path.
+
+  This allows for workflow names that are not also directory paths within the
+  pathogen source, which is useful for pathogens that are structured
+  non-conventionally for one reason or another.  The decoupling of workflow
+  names from paths also means that the workflow can be relocated within the
+  pathogen repo without breaking the name (i.e. the external interface to the
+  workflow).
+
+  As an example, the following workflow registration:
+
+  ```yaml
+  workflows:
+    phylogenetic:
+      path: .
+      compatibility:
+        nextstrain run: yes
+  ```
+
+  would allow invocation of a `phylogenetic` workflow located at the top-level
+  of the pathogen source, such as in [zika-tutorial](https://github.com/nextstrain/zika-tutorial).
+  ([#481](https://github.com/nextstrain/cli/pull/481))
+
 
 (v10-3-0)=
 ## 10.3.0 (26 September 2025)

--- a/doc/commands/run.rst
+++ b/doc/commands/run.rst
@@ -72,7 +72,9 @@ positional arguments
     for valid workflow names.
 
     Workflow names conventionally correspond directly to directory
-    paths in the pathogen source, but this may not always be the case.
+    paths in the pathogen source, but this may not always be the case:
+    the pathogen's registration info can provide an explicit path for a
+    workflow name.
 
     Required.
 

--- a/nextstrain/cli/command/run.py
+++ b/nextstrain/cli/command/run.py
@@ -80,7 +80,9 @@ def register_parser(subparser):
             for valid workflow names.
 
             Workflow names conventionally correspond directly to directory
-            paths in the pathogen source, but this may not always be the case.
+            paths in the pathogen source, but this may not always be the case:
+            the pathogen's registration info can provide an explicit path for a
+            workflow name.
 
             Required.
             """))


### PR DESCRIPTION
This decoupling of workflow names from paths was always expected and intended to be possible, and now it is.

Related-to: <https://github.com/nextstrain/zika-tutorial/pull/19>
Related-to: <https://github.com/nextstrain/public/issues/1>
## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
