### PR TITLE
dev: Update the example `git push …` command emitted by devel/release

### DIFF
--- a/devel/release
+++ b/devel/release
@@ -171,7 +171,7 @@ remind-to-push() {
     echo
     echo "Please remember to push, including tags:"
     echo
-    echo "   git push origin master tag $version"
+    echo "   git push origin tag $version && sleep 5 && git push origin master"
     echo
     echo "CI will build dists for the release tag and publish them after tests pass."
     echo


### PR DESCRIPTION
This is what I've been doing myself for a long while now.  Pushing the tag slightly before master lets the tag's CI kick off first, thus getting the release out sooner.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
