### PR TITLE
dev: Switch types-boto3-s3 to a dev-only dep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* The dependency on `types-boto3-s3` is now development-only (the `dev` extra).
+  This eases Conda packaging and is consistent with dev-only dependencies on
+  other type definition packages.
+  ([#485](https://github.com/nextstrain/cli/pull/485))
+
 
 # 10.4.0 (13 October 2025)
 

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -16,6 +16,14 @@ development source code and as such may not be routinely kept up to date.
 (v-next)=
 ## __NEXT__
 
+(v-next-bug-fixes)=
+### Bug fixes
+
+* The dependency on `types-boto3-s3` is now development-only (the `dev` extra).
+  This eases Conda packaging and is consistent with dev-only dependencies on
+  other type definition packages.
+  ([#485](https://github.com/nextstrain/cli/pull/485))
+
 
 (v10-4-0)=
 ## 10.4.0 (13 October 2025)

--- a/nextstrain/cli/types.py
+++ b/nextstrain/cli/types.py
@@ -6,7 +6,7 @@ import argparse
 import builtins
 import sys
 from pathlib import Path
-from typing import Callable, Iterable, List, Mapping, Optional, Protocol, Tuple, Union, TYPE_CHECKING, runtime_checkable
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Protocol, Tuple, Union, TYPE_CHECKING, runtime_checkable
 # TODO: Use typing.TypeAlias once Python 3.10 is the minimum supported version.
 from typing_extensions import TypeAlias
 
@@ -49,7 +49,11 @@ SetupTestResultStatus: TypeAlias = Union[bool, None, EllipsisType]
 UpdateStatus = Optional[bool]
 
 # Re-export boto3 S3 resource types we use for convenience.
-from types_boto3_s3.service_resource import Bucket as S3Bucket, Object as S3Object # noqa: F401 (for re-export)
+if TYPE_CHECKING:
+    from types_boto3_s3.service_resource import Bucket as S3Bucket, Object as S3Object # noqa: F401 (for re-export)
+else:
+    S3Bucket = Any
+    S3Object = Any
 
 
 @runtime_checkable

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ setup(
         "pyparsing >=3.0.0",
         "pyyaml >=5.3.1",
         "requests",
-        "types-boto3-s3",
         "typing_extensions >=3.7.4",
         "wcmatch >=6.0",
         "wrapt",
@@ -154,6 +153,7 @@ setup(
             "sphinx-markdown-tables !=0.0.16",
             "sphinx_rtd_theme",
             "types-boto3",
+            "types-boto3-s3",
             "types-botocore",
 
             # Only necessary for urllib3 <2.0.0, which we only have to use on


### PR DESCRIPTION
Eases Conda packaging¹ and is probably what I should have done in the first place anyway to be consistent with other types usage (and reduce Python memory usage of unnecessary imports).

¹ <https://github.com/bioconda/bioconda-recipes/pull/60071#issuecomment-3402750326>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
