### PR TITLE
standalone-installer-unix: Use new aarch64 builds for Linux

### DIFF
--- a/.github/workflows/standalone-installers.yaml
+++ b/.github/workflows/standalone-installers.yaml
@@ -37,6 +37,8 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
           - macos-15-intel
           - macos-14        # (aarch64)
           - macos-15        # (aarch64)

--- a/bin/standalone-installer-unix
+++ b/bin/standalone-installer-unix
@@ -109,7 +109,9 @@ target-triple() {
 
     case "$KERNEL" in
         Linux)
-            [[ "$machine" == x86_64 ]] || die "unsupported architecture: $machine"
+               [[ "$machine" == x86_64 ]] \
+            || ([[ "$machine" == aarch64 ]] && version-gte 10.4.2) \
+            || die "unsupported architecture: $machine"
             vendor=unknown
             os=linux-gnu
             ;;


### PR DESCRIPTION
Conditions on the Nextstrain CLI version being requested, as aarch64 builds¹ will only be available going forward for new releases.  Assumes the next release will be 10.4.2!

We must wait to merge this until after the first release (i.e. 10.4.2) of the changes it depends on above.

¹ <https://github.com/nextstrain/cli/pull/489>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] ~Checks pass~ Post-merge installers check [passed](https://github.com/nextstrain/cli/actions/runs/20797921154)
- [x] ~Update changelog~ done in [#489](https://github.com/nextstrain/cli/pull/489)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
