### PR TITLE
Avoid newer versions of s3fs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ development source code and as such may not be routinely kept up to date.
 
 # __NEXT__
 
+## Bug fixes
+
+* Updated the s3fs dependency to avoid versions starting with 2025.12.0. This
+  maintains a dependency on `boto3` which is used for various commands.
+  ([#495](https://github.com/nextstrain/cli/pull/495))
 
 # 10.4.1 (14 October 2025)
 

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -16,6 +16,12 @@ development source code and as such may not be routinely kept up to date.
 (v-next)=
 ## __NEXT__
 
+(v-next-bug-fixes)=
+### Bug fixes
+
+* Updated the s3fs dependency to avoid versions starting with 2025.12.0. This
+  maintains a dependency on `boto3` which is used for various commands.
+  ([#495](https://github.com/nextstrain/cli/pull/495))
 
 (v10-4-1)=
 ## 10.4.1 (14 October 2025)

--- a/setup.py
+++ b/setup.py
@@ -118,12 +118,19 @@ setup(
         # declarations.
         #
         # Resolve the issue by using a specially-provided package extra from
-        # s3fs (first introduced with 2021.4.0) which causes them to declare an
-        # explicit dependency on aiobotocore's specially-provided package extra
-        # on boto3 so that dependency resolver can figure it out properly.
+        # s3fs (first introduced with 2021.4.0, removed in 2025.12.0) which
+        # causes them to declare an explicit dependency on aiobotocore's
+        # specially-provided package extra on boto3 so that dependency resolver
+        # can figure it out properly.
         #
-        # See <https://github.com/dask/s3fs/issues/357> and
-        # <https://github.com/nextstrain/cli/issues/133> for more background.
+        # Note that the upper limit is not future-proof and will likely cause
+        # issues down the road. There may be a better combination to use here,
+        # but that needs extra digging.
+        #
+        # More background:
+        # <https://github.com/dask/s3fs/issues/357>
+        # <https://github.com/nextstrain/cli/issues/133>
+        # <https://github.com/fsspec/s3fs/issues/994>
         #
         # What a mess.
         #
@@ -131,7 +138,7 @@ setup(
         # https://github.com/fsspec/filesystem_spec/pull/1358 that causes the
         # error described in https://github.com/fsspec/s3fs/issues/790
         "fsspec !=2023.9.1",
-        "s3fs[boto3] >=2021.04.0, !=2023.9.1",
+        "s3fs[boto3] >=2021.04.0, !=2023.9.1, <2025.12.0",
 
         # From 2.0.0 onwards, urllib3 is better typed, but not usable (given
         # our dep tree) on 3.8 and 3.9 so we use types-urllib3 there (see


### PR DESCRIPTION
## Description of proposed changes

The boto3 extra is no longer available in 2025.12.0. Since pip resolves versions before considering extras, it will by default pull the latest version then later show a warning:

    WARNING: s3fs 2025.12.0 does not provide the extra 'boto3'

This change seems permanent, so pin to avoid the version and future versions.

## Related issue(s)

- Closes #493
- https://github.com/fsspec/s3fs/issues/994

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
