### PR TITLE
Update dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ development source code and as such may not be routinely kept up to date.
 
 ## Bug fixes
 
+* Updated code to support the latest version of `wrapt`, used to show
+  `--dry-run` outputs.
+  ([#499](https://github.com/nextstrain/cli/pull/499))
 * Updated the dependency list to explicitly include `boto3`, used for various
   commands.
   ([#499](https://github.com/nextstrain/cli/pull/499))

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -40,6 +40,9 @@ development source code and as such may not be routinely kept up to date.
 (v-next-bug-fixes)=
 ### Bug fixes
 
+* Updated code to support the latest version of `wrapt`, used to show
+  `--dry-run` outputs.
+  ([#499](https://github.com/nextstrain/cli/pull/499))
 * Updated the dependency list to explicitly include `boto3`, used for various
   commands.
   ([#499](https://github.com/nextstrain/cli/pull/499))

--- a/nextstrain/cli/console.py
+++ b/nextstrain/cli/console.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import contextmanager, ExitStack, redirect_stdout, redirect_stderr
 from functools import wraps
 from typing import Callable, TextIO
-from wrapt import ObjectProxy
+from wrapt import BaseObjectProxy # pyright: ignore[reportAttributeAccessIssue]
 
 
 def auto_dry_run_indicator(getter: Callable[..., bool] = lambda opts, *args, **kwargs: opts.dry_run):
@@ -83,7 +83,7 @@ def dry_run_indicator(dry_run: bool = False):
         yield dry_run
 
 
-class LinePrefixer(ObjectProxy): # pyright: ignore[reportUntypedBaseClass]
+class LinePrefixer(BaseObjectProxy): # pyright: ignore[reportUntypedBaseClass]
     """
     Add *prefix* to every line written to *file*.
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "requests",
         "typing_extensions >=3.7.4",
         "wcmatch >=6.0",
-        "wrapt <2.0.0",
+        "wrapt >=2.0.0",
 
         # We use fsspec's S3 support, which has a runtime dep on s3fs.  s3fs
         # itself requires aiobotocore, which in turn requires very specific


### PR DESCRIPTION
## Description of proposed changes

This PR improves dependency declarations for fsspec, boto3, and wrapt. See commits for details.

## Related issue(s)

Closes #496

## Checklist

- [x] Checks pass
- [x] pip doesn't do any crazy backtracking ([ref](https://github.com/nextstrain/cli/pull/499#discussion_r2790940573))
- [x] Update changelog