### PR TITLE
devel: Use the environment's Bash

### DIFF
--- a/devel/create-github-release
+++ b/devel/create-github-release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s extglob
 

--- a/devel/generate-doc
+++ b/devel/generate-doc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 devel="$(dirname "$0")"

--- a/devel/pyoxidizer
+++ b/devel/pyoxidizer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 shopt -s extglob failglob
 

--- a/devel/pytest
+++ b/devel/pytest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 cd "$(dirname "$0")/.."

--- a/devel/reflow-markdown
+++ b/devel/reflow-markdown
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Reflows paragraphs in Markdown to single long lines while preserving verbatim
 # code blocks, lists, and what not.
 set -euo pipefail

--- a/devel/release
+++ b/devel/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 devel="$(dirname "$0")"

--- a/devel/rtd-pre-build
+++ b/devel/rtd-pre-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 devel="$(dirname "$0")"

--- a/devel/setup-venv
+++ b/devel/setup-venv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 base="$(cd "$(dirname "$0")/.."; pwd)"

--- a/devel/update-version
+++ b/devel/update-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 devel="$(dirname "$0")"

--- a/devel/venv-run
+++ b/devel/venv-run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1091
 set -eou pipefail
 

--- a/devel/within-container
+++ b/devel/within-container
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # usage: devel/within-container <image> [<argv0> [<argv1> [...]]]
 set -euo pipefail
 


### PR DESCRIPTION
## Description of proposed changes

We definitely don't need "the system bash", which is what /bin/bash is. We want "the bash the user wants", which will often be the system bash, but not always.

The main motivation is that /bin/bash on macOS is stuck on an ancient version due to licensing issues, and users might prefer another Bash in their environments.

Commit message copied from https://github.com/nextstrain/shared/commit/bc7518079d0f47e120213528c435082718d361ea

## Related issue(s)

Closes #46

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Update changelog~ N/A, dev change

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
