### PR TITLE
doc: Update link to cloud-init user data format

### DIFF
--- a/doc/aws-batch.md
+++ b/doc/aws-batch.md
@@ -542,7 +542,7 @@ which only needs to be ephemeral so as not to incur increasing costs.
 [launch template]: https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html
 [create-launch-template]: https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchTemplates:
 [batch-launch-template]: https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html
-[cloud-init user data format]: https://cloudinit.readthedocs.io/en/latest/topics/format.html
+[cloud-init user data format]: https://cloudinit.readthedocs.io/en/latest/explanation/format/user-data-script.html
 [ecs-docker-options]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon
 [compute environment launch template]: https://docs.aws.amazon.com/batch/latest/userguide/create-compute-environment-managed-ec2.html
 [EFS volumes]: https://docs.aws.amazon.com/batch/latest/userguide/efs-volumes.html


### PR DESCRIPTION
The old link no longer works, and the relevant content has been moved to a more specific page.

Error flagged by [scheduled CI run](https://github.com/nextstrain/cli/actions/runs/21760529447):

```
Broken links found:
{
  "filename": "aws-batch.md",
  "lineno": 535,
  "status": "broken",
  "code": 0,
  "uri": "https://cloudinit.readthedocs.io/en/latest/topics/format.html",
  "info": "404 Client Error: Not Found for url: https://cloudinit.readthedocs.io/en/latest/explanation/format.html"
}
```

Related to https://github.com/canonical/cloud-init/issues/6730

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] linkcheck passes
- [x] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
