### PR TITLE
Add custom repr to LaxVersion

### DIFF
--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -891,6 +891,9 @@ class LaxVersion(Version):
         self.compliant = compliant
         self.original = original if original is not None else version
 
+    def __repr__(self) -> str:
+        return f"<Version({str(self)!r})>"
+
 
 T = TypeVar("T")
 

--- a/nextstrain/cli/util.py
+++ b/nextstrain/cli/util.py
@@ -821,15 +821,15 @@ def parse_version_lax(version: str) -> 'LaxVersion':
     ``0.dev0`` so it compares lowest against other public version identifiers.
 
     >>> parse_version_lax("1.2.3")
-    <Version('1.2.3')>
+    <LaxVersion('1.2.3')>
     >>> parse_version_lax("1.2.3-nope")
-    <Version('0.dev0+1.2.3.nope')>
+    <LaxVersion('0.dev0+1.2.3.nope')>
     >>> parse_version_lax("20221019T172207Z")
-    <Version('0.dev0+20221019t172207z')>
+    <LaxVersion('0.dev0+20221019t172207z')>
     >>> parse_version_lax("@invalid+@")
-    <Version('0.dev0+invalid')>
+    <LaxVersion('0.dev0+invalid')>
     >>> parse_version_lax("not@@ok")
-    <Version('0.dev0+not.ok')>
+    <LaxVersion('0.dev0+not.ok')>
     >>> parse_version_lax("20221019T172207Z") < parse_version_lax("20230525T143814Z")
     True
     """
@@ -892,7 +892,7 @@ class LaxVersion(Version):
         self.original = original if original is not None else version
 
     def __repr__(self) -> str:
-        return f"<Version({str(self)!r})>"
+        return f"<LaxVersion({str(self)!r})>"
 
 
 T = TypeVar("T")


### PR DESCRIPTION
## Description of proposed changes

This is more robust than relying on repr from the base class which may change across versions, and distinguishes the custom class from its base class.

## Related issue(s)

Fixes [test failures](https://github.com/nextstrain/cli/actions/runs/24470284428/job/71508396288) caused by https://github.com/pypa/packaging/commit/d40bec383fd206a94a95c84638065987cc1450db

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Update changelog~ no functional changes

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
