### PR TITLE
Suppress warning from cryptography about deprecated Python 3.8 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ development source code and as such may not be routinely kept up to date.
 * Updated the dependency list to explicitly include `boto3`, used for various
   commands.
   ([#499](https://github.com/nextstrain/cli/pull/499))
+* Suppress warning from cryptography about deprecated Python 3.8 support
+  ([#523](https://github.com/nextstrain/cli/pull/523))
 
 # 10.5.0 (25 March 2026)
 

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -32,6 +32,8 @@ development source code and as such may not be routinely kept up to date.
 * Updated the dependency list to explicitly include `boto3`, used for various
   commands.
   ([#499](https://github.com/nextstrain/cli/pull/499))
+* Suppress warning from cryptography about deprecated Python 3.8 support
+  ([#523](https://github.com/nextstrain/cli/pull/523))
 
 (v10-5-0)=
 ## 10.5.0 (25 March 2026)

--- a/nextstrain/cli/authn/session.py
+++ b/nextstrain/cli/authn/session.py
@@ -2,8 +2,18 @@
 Authentication sessions.
 """
 import boto3
-import jwt
-import jwt.exceptions
+import warnings
+
+# Ignore noisy warning from cryptography 47.0.0 about deprecated support for Python 3.8
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message = "Python 3\\.8 is no longer supported by the Python core team and support for it is deprecated",
+        category = UserWarning
+    )
+    import jwt
+    import jwt.exceptions
+
 import secrets
 
 from base64 import b64encode


### PR DESCRIPTION
## Description of proposed changes

Short-term solution for <https://github.com/nextstrain/cli/issues/522>. Similar to previous warning suppression added in <https://github.com/nextstrain/cli/commit/3977fee06321a7bc4c879e45dd32ec3cecc50326>

Cryptography 48.0.0, which has not been released yet, will drop support for Python 3.8,¹ so we should also drop support for 3.8 soon.

¹ <https://cryptography.io/en/latest/changelog/#v48-0-0>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
