### PR TITLE
Don't block releases on docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,7 +364,6 @@ jobs:
       - test-dist
       - test-standalone
       - lint
-      - doc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description of proposed changes

Linkcheck can fail during tag-triggered release runs because the new release docs may not exist on RTD yet. The docs build/linkcheck still runs and reports separately, but release no longer waits on that timing-sensitive check.

## Related issue(s)

- Initial [failure](https://github.com/nextstrain/cli/actions/runs/25397235653/attempts/1) of 11.0.0 release
- [Slack thread](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1778008317534129)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Update changelog~ N/A, dev change

## Previous implementations

- 6ea66c3
