### PR TITLE
Only run docs CI on schedule or code change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -345,13 +345,6 @@ jobs:
 
       - uses: ./src/.github/actions/run-integration-tests
 
-  doc:
-    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
-    with:
-      docs-directory: doc/
-      pip-install-target: .[dev]
-      make-target: dirhtml
-
   release:
     # Restricted to version tags by the "on: push: tags: …" config at the top.
     if: |2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,29 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - doc/**
+      - .github/workflows/docs.yaml
+
+  pull_request:
+    paths:
+      - doc/**
+      - .github/workflows/docs.yaml
+
+  workflow_dispatch:
+
+  # Routinely check that we continue to work in the face of external changes.
+  schedule:
+    # Every Monday at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * 1"
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
+    with:
+      docs-directory: doc/
+      pip-install-target: .[dev]
+      make-target: dirhtml


### PR DESCRIPTION
## Description of proposed changes

Previously, docs CI was run on every code change, even when docs were untouched. This tended to generate noise with many false positives.

Scheduled runs still catch when any existing links break, but at a weekly frequency so that any false positives are less noisy.

## Related issue(s)

- https://github.com/nextstrain/.github/issues/116

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] This PR has a "Docs / ci / build" check
- [x] Checks pass
- [x] ~Update changelog~ N/A, dev change

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
