### PR TITLE
.github/docs: Only run linkcheck on scheduled runs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,12 +4,8 @@ on:
   push:
     branches:
       - master
-    paths: &paths
-      - doc/**
-      - .github/workflows/docs.yaml
 
   pull_request:
-    paths: *paths
 
   workflow_dispatch:
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,3 +25,4 @@ jobs:
       docs-directory: doc/
       pip-install-target: .[dev]
       make-target: dirhtml
+      run-linkcheck: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Description of proposed changes

Reduce noise from false positive linkchecks by only running linkcheck for the scheduled workflow runs.

## Related issue(s)

Related to https://github.com/nextstrain/.github/pull/170

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
