### PR TITLE
Fix pytest warnings

### DIFF
--- a/tests/cram.py
+++ b/tests/cram.py
@@ -7,7 +7,7 @@ testsdir = Path(__file__).resolve().parent
 topdir = testsdir.parent
 
 @pytest.mark.skipif(os.name != "posix", reason = "cram requires a POSIX platform")
-@pytest.mark.parametrize("testfile", testsdir.glob("*.cram"), ids = str)
+@pytest.mark.parametrize("testfile", list(testsdir.glob("*.cram")), ids = str)
 def pytest_cram(testfile):
     # Check the exit status ourselves for nicer test output on failure
     result = run(["cram", testfile], cwd = topdir)

--- a/tests/markdown.py
+++ b/tests/markdown.py
@@ -8,10 +8,12 @@ topdir = testsdir.parent
 datadir = testsdir / "data/markdown/"
 
 def cases(pattern):
-    for case in datadir.glob(pattern):
-        yield pytest.param(
+    return [
+        pytest.param(
             case,
             id = str(case.relative_to(topdir)))
+        for case in datadir.glob(pattern)
+    ]
 
 
 @pytest.mark.parametrize("case", cases("roundtrip-*.md"))


### PR DESCRIPTION
Pytest 9.1.0 added a warning on non-Collection iterables used for parameterization (treated as an error per pytest.ini).

https://github.com/pytest-dev/pytest/releases/tag/9.1.0

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass (failing checks are unrelated)
- [x] ~Update changelog~ N/A, dev change

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
