### PR TITLE
Replace broken link with public repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -450,8 +450,8 @@ below.
 
 * Colorized and bolded output is disabled when stdout is not attached to a
   terminal (e.g. is redirected to a file, piped to another program, etc.) or
-  when the [`NO_COLOR` environment variable](https://no-color.org) is set to a
-  non-empty value.
+  when the [`NO_COLOR` environment variable](https://github.com/jcs/no_color/blob/@/index.md)
+  is set to a non-empty value.
   ([#419][])
 
 * The readability of `--help` output is improved by the addition of blank lines

--- a/doc/changes.md
+++ b/doc/changes.md
@@ -484,8 +484,8 @@ below.
 
 * Colorized and bolded output is disabled when stdout is not attached to a
   terminal (e.g. is redirected to a file, piped to another program, etc.) or
-  when the [`NO_COLOR` environment variable](https://no-color.org) is set to a
-  non-empty value.
+  when the [`NO_COLOR` environment variable](https://github.com/jcs/no_color/blob/@/index.md)
+  is set to a non-empty value.
   ([#419][])
 
 * The readability of `--help` output is improved by the addition of blank lines


### PR DESCRIPTION

## Description of proposed changes

[docs-ci](https://github.com/nextstrain/cli/actions/runs/27976460860/job/82795368857) flagged broken link that cannot be reached, so point to the public repo file that has the website data.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
